### PR TITLE
chore(deps): upgrade reqwest 0.11 to 0.12 and fix clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,12 +556,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1454,15 +1448,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper 0.14.32",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1471,7 +1468,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1484,9 +1481,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1639,6 +1638,16 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
@@ -2305,42 +2314,42 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-tls",
- "ipnet",
+ "hyper-util",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
 ]
 
 [[package]]
@@ -2430,15 +2439,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -2812,9 +2812,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3116,6 +3119,29 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3535,6 +3561,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3781,16 +3818,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ thiserror = "1.0"
 uuid = { version = "1.6", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 humantime = "2.1"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 urlencoding = "2.1"
 
 # Database

--- a/src/auto_fix.rs
+++ b/src/auto_fix.rs
@@ -241,8 +241,8 @@ impl DefaultAutoFixManager {
     fn analyze_ssm_agent_fixes(&self, result: &DiagnosticResult) -> Vec<FixAction> {
         let mut fixes = Vec::new();
 
-        if result.status == DiagnosticStatus::Error {
-            if result.message.contains("not registered") || result.message.contains("offline") {
+        if result.status == DiagnosticStatus::Error
+            && (result.message.contains("not registered") || result.message.contains("offline")) {
                 let instance_id = result
                     .details
                     .as_ref()
@@ -258,7 +258,6 @@ impl DefaultAutoFixManager {
                 .with_command("sudo systemctl restart amazon-ssm-agent".to_string());
                 fixes.push(fix);
             }
-        }
 
         fixes
     }
@@ -320,8 +319,8 @@ impl DefaultAutoFixManager {
     fn analyze_port_fixes(&self, result: &DiagnosticResult) -> Vec<FixAction> {
         let mut fixes = Vec::new();
 
-        if result.status == DiagnosticStatus::Error {
-            if result.message.contains("port in use") || result.message.contains("already bound") {
+        if result.status == DiagnosticStatus::Error
+            && (result.message.contains("port in use") || result.message.contains("already bound")) {
                 if let Some(details) = &result.details {
                     if let Some(process_info) = details.get("process_info") {
                         let process_name = process_info
@@ -353,7 +352,6 @@ impl DefaultAutoFixManager {
                 );
                 fixes.push(fix);
             }
-        }
 
         fixes
     }
@@ -557,8 +555,7 @@ impl DefaultAutoFixManager {
             if start_time.elapsed() > max_wait_time {
                 return Err(NimbusError::Aws(AwsError::Timeout {
                     operation: "Instance startup monitoring".to_string(),
-                })
-                .into());
+                }));
             }
 
             let describe_request = self
@@ -598,8 +595,7 @@ impl DefaultAutoFixManager {
                                         "Instance startup failed, current state: {}",
                                         state
                                     ),
-                                })
-                                .into());
+                                }));
                             }
 
                             // Continue monitoring for pending/starting states
@@ -610,8 +606,7 @@ impl DefaultAutoFixManager {
                     error!("Failed to check instance state during monitoring: {}", e);
                     return Err(NimbusError::Aws(AwsError::Ec2ServiceError {
                         message: format!("Failed to check instance state: {}", e),
-                    })
-                    .into());
+                    }));
                 }
             }
 
@@ -642,8 +637,7 @@ impl DefaultAutoFixManager {
             if start_time.elapsed() > timeout {
                 return Err(NimbusError::Aws(AwsError::Timeout {
                     operation: "SSM registration wait".to_string(),
-                })
-                .into());
+                }));
             }
 
             let state = self.check_ssm_agent_state(instance_id).await?;
@@ -836,8 +830,7 @@ impl DefaultAutoFixManager {
                 );
                 Err(NimbusError::Aws(AwsError::SsmServiceError {
                     message: format!("Failed to check SSM agent state: {}", e),
-                })
-                .into())
+                }))
             }
         }
     }
@@ -873,8 +866,7 @@ impl DefaultAutoFixManager {
                     error!("No command information returned");
                     Err(NimbusError::Aws(AwsError::SsmServiceError {
                         message: "No command information returned".to_string(),
-                    })
-                    .into())
+                    }))
                 }
             }
             Err(e) => {
@@ -884,8 +876,7 @@ impl DefaultAutoFixManager {
                 );
                 Err(NimbusError::Aws(AwsError::SsmServiceError {
                     message: format!("Failed to send SSM restart command: {}", e),
-                })
-                .into())
+                }))
             }
         }
     }

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -275,22 +275,13 @@ impl AwsManager {
                             .as_ref()
                             .and_then(|s| s.name.as_ref())
                             .map(|n| n.as_str().to_string()),
-                        private_ip: instance.private_ip_address
-                            .as_ref()
-                            .map(|ip| ip.clone()),
-                        public_ip: instance.public_ip_address
-                            .as_ref()
-                            .map(|ip| ip.clone()),
+                        private_ip: instance.private_ip_address.clone(),
+                        public_ip: instance.public_ip_address.clone(),
                         availability_zone: instance.placement
                             .as_ref()
-                            .and_then(|p| p.availability_zone.as_ref())
-                            .map(|az| az.clone()),
-                        vpc_id: instance.vpc_id
-                            .as_ref()
-                            .map(|vpc| vpc.clone()),
-                        subnet_id: instance.subnet_id
-                            .as_ref()
-                            .map(|subnet| subnet.clone()),
+                            .and_then(|p| p.availability_zone.as_ref()).cloned(),
+                        vpc_id: instance.vpc_id.clone(),
+                        subnet_id: instance.subnet_id.clone(),
                     };
                     
                     debug!("Instance info retrieved: {:?}", info);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -36,6 +36,7 @@ use crate::multi_session_ui::MultiSessionUi;
 #[cfg(feature = "persistence")]
 use crate::persistence::{PersistenceManager, SqlitePersistenceManager};
 
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_connect_with_recovery(
     instance_id: String,
     local_port: u16,
@@ -292,6 +293,7 @@ pub async fn handle_terminate_with_recovery(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_connect(
     instance_id: String,
     local_port: u16,
@@ -695,11 +697,9 @@ pub async fn handle_connect(
             error!("Failed to create session: {}", e);
 
             // Convert to appropriate NimbusError
-            let ec2_error = match e {
-                _ => NimbusError::Session(crate::error::SessionError::CreationFailed {
-                    reason: e.to_string(),
-                }),
-            };
+            let ec2_error = NimbusError::Session(crate::error::SessionError::CreationFailed {
+                reason: e.to_string(),
+            });
 
             return Err(ec2_error.into());
         }
@@ -758,7 +758,7 @@ pub async fn handle_terminate(session_id: String, _config: &Config) -> Result<()
         Err(e) => {
             error!("Failed to terminate session: {}", e);
             println!("❌ Failed to terminate session: {}", e);
-            return Err(e.into());
+            return Err(e);
         }
     }
 
@@ -1694,12 +1694,10 @@ pub async fn handle_config(action: ConfigCommands, config: &Config) -> Result<()
                 } else {
                     config_path
                 }
+            } else if config_path.extension().and_then(|s| s.to_str()) != Some("json") {
+                config_path.with_extension("json")
             } else {
-                if config_path.extension().and_then(|s| s.to_str()) != Some("json") {
-                    config_path.with_extension("json")
-                } else {
-                    config_path
-                }
+                config_path
             };
 
             let default_config = Config::default();
@@ -2315,16 +2313,14 @@ pub async fn handle_vscode(action: VsCodeCommands, config: &Config) -> Result<()
 
                                                     // End skip when we hit a new section or empty line
                                                     if skip_section {
-                                                        if trimmed.starts_with("Host ")
-                                                            && !trimmed.contains("ec2-")
-                                                        {
-                                                            skip_section = false;
-                                                        } else if trimmed.is_empty()
-                                                            && result_lines
-                                                                .last()
-                                                                .map_or(false, |l: &String| {
-                                                                    l.trim().is_empty()
-                                                                })
+                                                        if (trimmed.starts_with("Host ")
+                                                            && !trimmed.contains("ec2-"))
+                                                            || (trimmed.is_empty()
+                                                                && result_lines
+                                                                    .last()
+                                                                    .is_some_and(|l: &String| {
+                                                                        l.trim().is_empty()
+                                                                    }))
                                                         {
                                                             skip_section = false;
                                                         }
@@ -3601,6 +3597,7 @@ pub async fn handle_diagnose(action: DiagnosticCommands, _config: &Config) -> Re
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_precheck(
     instance_id: String,
     local_port: Option<u16>,
@@ -3764,6 +3761,7 @@ pub async fn handle_precheck(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_fix(
     instance_id: String,
     local_port: Option<u16>,
@@ -3927,11 +3925,11 @@ pub async fn handle_fix(
             auto_fix::RiskLevel::Critical => "🚨",
         };
         println!(
-            "   {}. {} {} - {}",
+            "   {}. {} {} - Risk: {:?}",
             index + 1,
             risk_icon,
             action.description,
-            format!("Risk: {:?}", action.risk_level)
+            action.risk_level
         );
         if let Some(command) = &action.command {
             println!("      Command: {}", command);

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -195,9 +195,11 @@ pub trait DiagnosticManager {
     fn register_progress_callback(&mut self, callback: Box<dyn Fn(DiagnosticProgress) + Send + Sync>);
 }
 
+type ProgressCallback = std::sync::Arc<std::sync::Mutex<Box<dyn Fn(DiagnosticProgress) + Send + Sync>>>;
+
 /// Default implementation of the diagnostic manager
 pub struct DefaultDiagnosticManager {
-    progress_callback: Option<std::sync::Arc<std::sync::Mutex<Box<dyn Fn(DiagnosticProgress) + Send + Sync>>>>,
+    progress_callback: Option<ProgressCallback>,
     diagnostic_items: Vec<String>,
     realtime_feedback: Option<std::sync::Arc<RealtimeFeedbackManager>>,
 }
@@ -1303,11 +1305,9 @@ impl DiagnosticManager for DefaultDiagnosticManager {
         info!("Starting precheck diagnostics for instance: {}", config.instance_id);
         
         // For precheck, run only essential items
-        let precheck_items = vec![
-            "instance_state",
+        let precheck_items = ["instance_state",
             "local_port_availability",
-            "iam_permissions",
-        ];
+            "iam_permissions"];
         
         let start_time = Instant::now();
         let mut results = Vec::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -186,12 +186,7 @@ impl From<anyhow::Error> for NimbusError {
 impl NimbusError {
     /// Check if error is recoverable
     pub fn is_recoverable(&self) -> bool {
-        match self {
-            NimbusError::Connection(ConnectionError::PreventiveCheckFailed { .. }) => true,
-            NimbusError::Session(SessionError::CreationFailed { .. }) => true,
-            NimbusError::Io(_) => true,
-            _ => false,
-        }
+        matches!(self, NimbusError::Connection(ConnectionError::PreventiveCheckFailed { .. }) | NimbusError::Session(SessionError::CreationFailed { .. }) | NimbusError::Io(_))
     }
     
     /// Get error severity level

--- a/src/health.rs
+++ b/src/health.rs
@@ -78,7 +78,7 @@ impl DefaultHealthChecker {
     /// Execute AWS CLI command to check SSM session
     async fn check_aws_ssm_session(&self, session_id: &str) -> Result<bool> {
         let output = Command::new("aws")
-            .args(&["ssm", "describe-sessions", "--session-id", session_id])
+            .args(["ssm", "describe-sessions", "--session-id", session_id])
             .output();
             
         match output {

--- a/src/iam_diagnostics.rs
+++ b/src/iam_diagnostics.rs
@@ -306,7 +306,7 @@ impl DefaultIamDiagnostics {
                         
                         if let Some(arn) = profile_arn {
                             // ARNからプロファイル名を抽出
-                            let profile_name = arn.split('/').last().unwrap_or("unknown").to_string();
+                            let profile_name = arn.split('/').next_back().unwrap_or("unknown").to_string();
                             
                             // インスタンスプロファイルの詳細を取得
                             let iam_info = self.get_instance_profile_details(&profile_name).await?;
@@ -577,10 +577,7 @@ impl DefaultIamDiagnostics {
         
         // EC2インスタンスメタデータサービスから取得を試行
         // 注意: これは実際のEC2インスタンス上でのみ動作する
-        match self.get_instance_metadata_token_expiration().await {
-            Ok(expiration) => Some(expiration),
-            Err(_) => None,
-        }
+        (self.get_instance_metadata_token_expiration().await).ok()
     }
     
     /// EC2インスタンスメタデータサービスからトークン有効期限を取得
@@ -608,7 +605,7 @@ impl DefaultIamDiagnostics {
         let role_name = creds_response.text().await?;
         
         let expiration_response = client
-            .get(&format!("http://169.254.169.254/latest/meta-data/iam/security-credentials/{}", role_name.trim()))
+            .get(format!("http://169.254.169.254/latest/meta-data/iam/security-credentials/{}", role_name.trim()))
             .header("X-aws-ec2-metadata-token", &token)
             .timeout(Duration::from_secs(2))
             .send()
@@ -1269,8 +1266,6 @@ impl IamDiagnostics for DefaultIamDiagnostics {
 }
 
 // 必要な依存関係を追加
-use reqwest;
-use urlencoding;
 
 #[cfg(test)]
 mod tests {

--- a/src/instance_diagnostics.rs
+++ b/src/instance_diagnostics.rs
@@ -444,7 +444,7 @@ impl InstanceDiagnostics for DefaultInstanceDiagnostics {
                             // Convert AWS SDK DateTime to chrono DateTime
                             let timestamp = t.as_secs_f64();
                             chrono::DateTime::from_timestamp(timestamp as i64, (timestamp.fract() * 1_000_000_000.0) as u32)
-                                .unwrap_or_else(|| chrono::Utc::now())
+                                .unwrap_or_else(chrono::Utc::now)
                         }),
                         architecture: instance.architecture.as_ref().map(|a| a.as_str().to_string()),
                         hypervisor: instance.hypervisor.as_ref().map(|h| h.as_str().to_string()),

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::SystemTime;
-use tracing;
 use tracing_appender::{non_blocking, rolling};
 use tracing_subscriber::{
     fmt::{self, format::FmtSpan},

--- a/src/network_diagnostics.rs
+++ b/src/network_diagnostics.rs
@@ -191,7 +191,7 @@ impl DefaultNetworkDiagnostics {
                     .map(|entry| NetworkAclEntry {
                         rule_number: entry.rule_number.unwrap_or(0),
                         protocol: entry.protocol.clone().unwrap_or_default(),
-                        rule_action_deny: entry.rule_action.as_ref().map_or(false, |action| action.as_str() == "deny"),
+                        rule_action_deny: entry.rule_action.as_ref().is_some_and(|action| action.as_str() == "deny"),
                         port_range: entry.port_range.as_ref().map(|range| PortRange {
                             from: range.from.unwrap_or(0),
                             to: range.to.unwrap_or(0),
@@ -262,8 +262,7 @@ impl DefaultNetworkDiagnostics {
                 if instance.instance_id.as_deref() == Some(instance_id) {
                     let security_groups: Vec<String> = instance.security_groups()
                         .iter()
-                        .filter_map(|sg| sg.group_id.as_ref())
-                        .map(|id| id.clone())
+                        .filter_map(|sg| sg.group_id.as_ref()).cloned()
                         .collect();
                     
                     debug!("Instance security groups: {:?}", security_groups);
@@ -279,11 +278,9 @@ impl DefaultNetworkDiagnostics {
     async fn check_ssm_vpc_endpoints(&self, vpc_id: &str) -> Result<Vec<VpcEndpointInfo>> {
         debug!("Checking SSM VPC endpoints for VPC: {}", vpc_id);
         
-        let required_services = vec![
-            format!("com.amazonaws.{}.ssm", self.aws_manager.region()),
+        let required_services = [format!("com.amazonaws.{}.ssm", self.aws_manager.region()),
             format!("com.amazonaws.{}.ssmmessages", self.aws_manager.region()),
-            format!("com.amazonaws.{}.ec2messages", self.aws_manager.region()),
-        ];
+            format!("com.amazonaws.{}.ec2messages", self.aws_manager.region())];
         
         let response = self.aws_manager.ec2_client
             .describe_vpc_endpoints()
@@ -304,15 +301,9 @@ impl DefaultNetworkDiagnostics {
                 (&endpoint.service_name, &endpoint.vpc_endpoint_id, &endpoint.state) {
                 
                 if required_services.iter().any(|service| service == service_name) {
-                    let route_table_ids = endpoint.route_table_ids()
-                        .iter()
-                        .map(|id| id.clone())
-                        .collect();
+                    let route_table_ids = endpoint.route_table_ids().to_vec();
                     
-                    let subnet_ids = endpoint.subnet_ids()
-                        .iter()
-                        .map(|id| id.clone())
-                        .collect();
+                    let subnet_ids = endpoint.subnet_ids().to_vec();
                     
                     found_endpoints.push(VpcEndpointInfo {
                         endpoint_id: endpoint_id.clone(),
@@ -351,8 +342,7 @@ impl DefaultNetworkDiagnostics {
                     if let Some(protocol) = &rule.ip_protocol {
                         let cidr_blocks: Vec<String> = rule.ip_ranges()
                             .iter()
-                            .filter_map(|range| range.cidr_ip.as_ref())
-                            .map(|cidr| cidr.clone())
+                            .filter_map(|range| range.cidr_ip.as_ref()).cloned()
                             .collect();
                         
                         rules.push(SecurityGroupRule {
@@ -365,8 +355,7 @@ impl DefaultNetworkDiagnostics {
                             cidr_blocks,
                             description: rule.ip_ranges()
                                 .first()
-                                .and_then(|range| range.description.as_ref())
-                                .map(|desc| desc.clone()),
+                                .and_then(|range| range.description.as_ref()).cloned(),
                         });
                     }
                 }
@@ -376,8 +365,7 @@ impl DefaultNetworkDiagnostics {
                     if let Some(protocol) = &rule.ip_protocol {
                         let cidr_blocks: Vec<String> = rule.ip_ranges()
                             .iter()
-                            .filter_map(|range| range.cidr_ip.as_ref())
-                            .map(|cidr| cidr.clone())
+                            .filter_map(|range| range.cidr_ip.as_ref()).cloned()
                             .collect();
                         
                         rules.push(SecurityGroupRule {
@@ -390,8 +378,7 @@ impl DefaultNetworkDiagnostics {
                             cidr_blocks,
                             description: rule.ip_ranges()
                                 .first()
-                                .and_then(|range| range.description.as_ref())
-                                .map(|desc| desc.clone()),
+                                .and_then(|range| range.description.as_ref()).cloned(),
                         });
                     }
                 }
@@ -473,8 +460,7 @@ impl DefaultNetworkDiagnostics {
         
         let subnet_associations: Vec<String> = route_table.associations()
             .iter()
-            .filter_map(|assoc| assoc.subnet_id.as_ref())
-            .map(|id| id.clone())
+            .filter_map(|assoc| assoc.subnet_id.as_ref()).cloned()
             .collect();
         
         let routes: Vec<RouteInfo> = route_table.routes()
@@ -649,8 +635,8 @@ impl NetworkDiagnostics for DefaultNetworkDiagnostics {
                         let has_https_outbound = rules.iter().any(|rule| {
                             rule.rule_type == "egress" &&
                             (rule.protocol == "tcp" || rule.protocol == "-1") &&
-                            (rule.to_port.map_or(false, |port| port >= 443) || rule.protocol == "-1") &&
-                            (rule.from_port.map_or(false, |port| port <= 443) || rule.protocol == "-1") &&
+                            (rule.to_port.is_some_and(|port| port >= 443) || rule.protocol == "-1") &&
+                            (rule.from_port.is_some_and(|port| port <= 443) || rule.protocol == "-1") &&
                             (rule.cidr_blocks.contains(&"0.0.0.0/0".to_string()) || !rule.cidr_blocks.is_empty())
                         });
                         
@@ -668,13 +654,13 @@ impl NetworkDiagnostics for DefaultNetworkDiagnostics {
                         if has_https_outbound {
                             Ok(DiagnosticResult::success(
                                 "security_groups".to_string(),
-                                format!("Security groups allow HTTPS outbound traffic (required for SSM)"),
+                                "Security groups allow HTTPS outbound traffic (required for SSM)".to_string(),
                                 start_time.elapsed(),
                             ).with_details(details))
                         } else {
                             Ok(DiagnosticResult::error(
                                 "security_groups".to_string(),
-                                format!("Security groups do not allow HTTPS outbound traffic on port 443 (required for SSM)"),
+                                "Security groups do not allow HTTPS outbound traffic on port 443 (required for SSM)".to_string(),
                                 start_time.elapsed(),
                                 Severity::Critical,
                             ).with_details(details).with_auto_fixable(true))
@@ -714,13 +700,13 @@ impl NetworkDiagnostics for DefaultNetworkDiagnostics {
                         // Check for internet gateway or NAT gateway route
                         let has_internet_route = route_table.routes.iter().any(|route| {
                             route.destination_cidr_block.as_deref() == Some("0.0.0.0/0") &&
-                            (route.gateway_id.as_ref().map_or(false, |gw| gw.starts_with("igw-")) ||
+                            (route.gateway_id.as_ref().is_some_and(|gw| gw.starts_with("igw-")) ||
                              route.nat_gateway_id.is_some())
                         });
                         
                         // Check for VPC endpoint routes
                         let has_vpc_endpoint_routes = route_table.routes.iter().any(|route| {
-                            route.gateway_id.as_ref().map_or(false, |gw| gw.starts_with("vpce-"))
+                            route.gateway_id.as_ref().is_some_and(|gw| gw.starts_with("vpce-"))
                         });
                         
                         let details = serde_json::json!({
@@ -933,13 +919,13 @@ impl NetworkDiagnostics for DefaultNetworkDiagnostics {
                             
                             let result = if endpoint_issues.is_empty() {
                                 DiagnosticResult::success(
-                                    format!("vpc_endpoint_{}", endpoint.service_name.split('.').last().unwrap_or("unknown")),
+                                    format!("vpc_endpoint_{}", endpoint.service_name.split('.').next_back().unwrap_or("unknown")),
                                     format!("VPC endpoint {} is properly configured", endpoint.service_name),
                                     start_time.elapsed(),
                                 ).with_details(details)
                             } else {
                                 DiagnosticResult::warning(
-                                    format!("vpc_endpoint_{}", endpoint.service_name.split('.').last().unwrap_or("unknown")),
+                                    format!("vpc_endpoint_{}", endpoint.service_name.split('.').next_back().unwrap_or("unknown")),
                                     format!("VPC endpoint {} has issues: {}", endpoint.service_name, endpoint_issues.join(", ")),
                                     start_time.elapsed(),
                                     Severity::Medium,
@@ -986,7 +972,7 @@ impl NetworkDiagnostics for DefaultNetworkDiagnostics {
                         let mut sg_rules_map: HashMap<String, Vec<&SecurityGroupRule>> = HashMap::new();
                         
                         for rule in &rules {
-                            sg_rules_map.entry(rule.group_id.clone()).or_insert_with(Vec::new).push(rule);
+                            sg_rules_map.entry(rule.group_id.clone()).or_default().push(rule);
                         }
                         
                         // Analyze each security group individually
@@ -1000,8 +986,8 @@ impl NetworkDiagnostics for DefaultNetworkDiagnostics {
                             let has_https_outbound = sg_rules.iter().any(|rule| {
                                 rule.rule_type == "egress" &&
                                 (rule.protocol == "tcp" || rule.protocol == "-1") &&
-                                (rule.to_port.map_or(false, |port| port >= 443) || rule.protocol == "-1") &&
-                                (rule.from_port.map_or(false, |port| port <= 443) || rule.protocol == "-1") &&
+                                (rule.to_port.is_some_and(|port| port >= 443) || rule.protocol == "-1") &&
+                                (rule.from_port.is_some_and(|port| port <= 443) || rule.protocol == "-1") &&
                                 (rule.cidr_blocks.contains(&"0.0.0.0/0".to_string()) || !rule.cidr_blocks.is_empty())
                             });
                             
@@ -1028,8 +1014,8 @@ impl NetworkDiagnostics for DefaultNetworkDiagnostics {
                                 let has_port = sg_rules.iter().any(|rule| {
                                     rule.rule_type == "egress" &&
                                     rule.protocol == "tcp" &&
-                                    rule.from_port.map_or(false, |from| from <= port) &&
-                                    rule.to_port.map_or(false, |to| to >= port)
+                                    rule.from_port.is_some_and(|from| from <= port) &&
+                                    rule.to_port.is_some_and(|to| to >= port)
                                 });
                                 
                                 if has_port {
@@ -1227,7 +1213,7 @@ impl NetworkDiagnostics for DefaultNetworkDiagnostics {
                         // Check for internet gateway routes
                         let has_igw_route = route_table.routes.iter().any(|route| {
                             route.destination_cidr_block.as_deref() == Some("0.0.0.0/0") &&
-                            route.gateway_id.as_ref().map_or(false, |gw| gw.starts_with("igw-"))
+                            route.gateway_id.as_ref().is_some_and(|gw| gw.starts_with("igw-"))
                         });
                         
                         if has_igw_route {
@@ -1349,7 +1335,7 @@ impl NetworkDiagnostics for DefaultNetworkDiagnostics {
                                 !entry.rule_action_deny &&
                                 entry.egress &&
                                 entry.protocol == "6" && // TCP
-                                entry.port_range.as_ref().map_or(false, |range| 
+                                entry.port_range.as_ref().is_some_and(|range| 
                                     range.from <= 443 && range.to >= 443)
                             });
                             

--- a/src/port_diagnostics.rs
+++ b/src/port_diagnostics.rs
@@ -195,10 +195,7 @@ impl DefaultPortDiagnostics {
 
     /// Check if a port is available by attempting to bind to it
     fn is_port_available(&self, port: u16) -> bool {
-        match TcpListener::bind(format!("127.0.0.1:{}", port)) {
-            Ok(_) => true,
-            Err(_) => false,
-        }
+        TcpListener::bind(format!("127.0.0.1:{}", port)).is_ok()
     }
 
     /// Get process information using sysinfo
@@ -234,7 +231,7 @@ impl DefaultPortDiagnostics {
     fn find_process_by_port_system_specific(&self, port: u16) -> Option<ProcessInfo> {
         // Use lsof on Unix systems
         let output = Command::new("lsof")
-            .args(&["-i", &format!(":{}", port), "-t"])
+            .args(["-i", &format!(":{}", port), "-t"])
             .output();
 
         if let Ok(output) = output {
@@ -248,7 +245,7 @@ impl DefaultPortDiagnostics {
 
         // Fallback to netstat
         let output = Command::new("netstat")
-            .args(&["-tlnp"])
+            .args(["-tlnp"])
             .output();
 
         if let Ok(output) = output {
@@ -336,7 +333,7 @@ impl DefaultPortDiagnostics {
     /// Find available ports in a range around the target port
     fn find_available_ports_in_range(&self, center_port: u16, range: u16) -> Vec<u16> {
         let start_port = center_port.saturating_sub(range);
-        let end_port = center_port.saturating_add(range).min(65535);
+        let end_port = center_port.saturating_add(range);
         
         let mut available_ports = Vec::new();
         

--- a/src/preventive_check.rs
+++ b/src/preventive_check.rs
@@ -237,7 +237,7 @@ impl PreventiveCheck for DefaultPreventiveCheck {
         // If instance is not in a good state, abort early
         if basic_state_result.status == DiagnosticStatus::Error && basic_state_result.severity == Severity::Critical {
             warn!("Critical instance state issue detected, aborting preventive checks");
-            let recommendations = self.generate_recommendations(&[basic_state_result.clone()]);
+            let recommendations = self.generate_recommendations(std::slice::from_ref(&basic_state_result));
             return Ok(PreventiveCheckResult {
                 overall_status: PreventiveCheckStatus::Critical,
                 connection_likelihood: ConnectionLikelihood::VeryLow,

--- a/src/realtime_feedback.rs
+++ b/src/realtime_feedback.rs
@@ -100,7 +100,7 @@ impl RealtimeFeedbackManager {
 
             loop {
                 // Check for interruption
-                if let Ok(_) = interrupt_rx.try_recv() {
+                if interrupt_rx.try_recv().is_ok() {
                     debug!("Received interrupt signal");
                     break;
                 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -357,6 +357,7 @@ impl ResourceMonitor {
 
 /// Resource violation types
 #[derive(Debug, Clone)]
+#[allow(clippy::enum_variant_names)]
 pub enum ResourceViolation {
     MemoryExceeded { current: f64, limit: f64 },
     CpuExceeded { current: f64, limit: f64 },

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,18 +29,15 @@ impl fmt::Display for SessionStatus {
 
 /// Session priority for resource management
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Default)]
 pub enum SessionPriority {
     Low = 0,
+    #[default]
     Normal = 1,
     High = 2,
     Critical = 3,
 }
 
-impl Default for SessionPriority {
-    fn default() -> Self {
-        SessionPriority::Normal
-    }
-}
 
 impl fmt::Display for SessionPriority {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/ssm_agent_diagnostics.rs
+++ b/src/ssm_agent_diagnostics.rs
@@ -283,13 +283,7 @@ impl DefaultSsmAgentDiagnostics {
         // Consider versions 3.0.0 and above as current
         // This is a simplified check - in production, you might want to check against
         // the latest available version from AWS
-        if major >= 3 {
-            true
-        } else if major == 2 && minor >= 3 {
-            true // 2.3.x and above are acceptable
-        } else {
-            false
-        }
+        major >= 3 || (major == 2 && minor >= 3)
     }
     
     /// Calculate time since last ping
@@ -407,13 +401,12 @@ impl DefaultSsmAgentDiagnostics {
             }
             
             // Patch version difference
-            if current_parts.len() >= 3 && latest_parts.len() >= 3 {
-                if current_parts[0] == latest_parts[0] 
+            if current_parts.len() >= 3 && latest_parts.len() >= 3
+                && current_parts[0] == latest_parts[0] 
                     && current_parts[1] == latest_parts[1] 
                     && current_parts[2] < latest_parts[2] {
                     return UpdateUrgency::Low;
                 }
-            }
         }
         
         UpdateUrgency::None
@@ -456,7 +449,7 @@ impl DefaultSsmAgentDiagnostics {
         }
         
         // Ensure score is between 0 and 100
-        score.max(0.0).min(100.0)
+        score.clamp(0.0, 100.0)
     }
     
     /// Calculate agent health metrics
@@ -1037,7 +1030,7 @@ impl SsmAgentDiagnostics for DefaultSsmAgentDiagnostics {
                         "registration_analysis".to_string(),
                         format!("Registration quality excellent: {:.1}% ({})", 
                             analysis.registration_quality_score,
-                            analysis.registration_status.to_string()),
+                            analysis.registration_status),
                         start_time.elapsed(),
                     ).with_details(details))
                 } else if analysis.registration_quality_score >= 60.0 {

--- a/src/vscode.rs
+++ b/src/vscode.rs
@@ -150,7 +150,7 @@ impl VsCodeIntegration {
         for path_str in common_paths {
             let path = if path_str.contains("{}") {
                 // Windowsのユーザーディレクトリを展開
-                if let Some(username) = std::env::var("USERNAME").ok() {
+                if let Ok(username) = std::env::var("USERNAME") {
                     PathBuf::from(path_str.replace("{}", &username))
                 } else {
                     continue;
@@ -485,7 +485,7 @@ Host {}
         {
             let _ = Command::new("osascript")
                 .arg("-e")
-                .arg(&format!(
+                .arg(format!(
                     r#"display notification "{}" with title "{}""#,
                     message.replace('\n', " - "),
                     title
@@ -666,7 +666,7 @@ Host {}
         // 末尾の余分な空行を削除
         while result_lines
             .last()
-            .map_or(false, |line| line.trim().is_empty())
+            .is_some_and(|line| line.trim().is_empty())
         {
             result_lines.pop();
         }


### PR DESCRIPTION
## 変更内容
- `reqwest` を 0.11 → 0.12 にアップグレード
- 全 clippy 警告を修正（CI の `cargo clippy -- -D warnings` をパス）

### テスト結果
- `cargo clippy -- -D warnings`: 警告ゼロ ✅
- `cargo test`: 65テスト全パス ✅

Closes #6