### PR TITLE
fix: resolve docs/implementation inconsistencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nimbus"
 version = "3.0.0"
 edition = "2021"
+rust-version = "1.70.0"
 description = "High-performance EC2 SSM connection manager with automatic session management"
 authors = ["Nimbus Team"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ cargo test
 cargo bench
 
 # デバッグログ
-RUST_LOG=debug nimbus connect --instance-id i-xxx
+NIMBUS_LOG_LEVEL=debug nimbus connect --instance-id i-xxx
 ```
 
 ## ライセンス

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -106,6 +106,29 @@ cp config.toml.example ~/.config/nimbus/config.toml
 | `ssh_identity_file` | string/null | `null` | SSH秘密鍵のパス |
 | `ssh_identities_only` | boolean | `false` | 指定した鍵のみを使用 |
 
+### diagnostic - 診断設定
+
+`diagnostic` セクションは省略可能です（すべてデフォルト値が適用されます）。
+
+| フィールド | 型 | デフォルト | 説明 |
+|-----------|-----|-----------|------|
+| `enabled` | boolean | `true` | 診断機能を有効化 |
+| `enabled_checks` | string[] | *(下記参照)* | 有効な診断項目のリスト |
+| `auto_fix_enabled` | boolean | `false` | 自動修復を有効化 |
+| `safe_auto_fix_only` | boolean | `true` | 安全な自動修復のみ実行 |
+| `parallel_execution` | boolean | `true` | 診断の並列実行を有効化 |
+| `timeout_seconds` | number | `30` | 診断タイムアウト（秒） |
+| `port_scan_range` | number | `10` | ローカルポート診断のスキャン範囲 |
+| `report_format` | string | `"text"` | レポート形式（text/json/yaml） |
+| `output_directory` | string | *(OS依存)* | レポート出力先ディレクトリ |
+| `realtime_feedback` | boolean | `true` | リアルタイムフィードバックを有効化 |
+| `feedback_refresh_interval_ms` | number | `100` | フィードバック更新間隔（ミリ秒） |
+| `enable_colors` | boolean | `true` | 出力のカラー表示を有効化 |
+| `auto_confirm_critical` | boolean | `false` | 重大な問題を自動確認 |
+
+`enabled_checks` のデフォルト値:
+`instance_state`, `ssm_agent`, `iam_permissions`, `vpc_endpoints`, `security_groups`, `network_connectivity`, `local_port_availability`
+
 ### 設定ファイル例
 
 ```json

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -42,34 +42,40 @@ pub struct TargetConfig {
 }
 
 impl TargetsConfig {
-    pub fn default_path() -> Result<PathBuf> {
-        // Prefer ~/.config on Unix-like platforms (including macOS) for consistency
-        // with the main config file and common CLI tool conventions.
-        let base_dir = if cfg!(windows) {
+    fn base_dir() -> Result<PathBuf> {
+        let dir = if cfg!(windows) {
             dirs::config_dir().context("Could not determine config directory")?
         } else {
             dirs::home_dir()
                 .map(|h| h.join(".config"))
                 .or_else(dirs::config_dir)
                 .context("Could not determine config directory")?
-        }
-        .join("nimbus");
+        };
+        Ok(dir.join("nimbus"))
+    }
 
-        Ok(base_dir.join("targets.json"))
+    /// Return candidate paths in priority order: JSON first, then TOML.
+    fn candidate_paths() -> Result<Vec<PathBuf>> {
+        let base = Self::base_dir()?;
+        Ok(vec![
+            base.join("targets.json"),
+            base.join("targets.toml"),
+        ])
     }
 
     pub async fn load(path: Option<&str>) -> Result<(Self, PathBuf)> {
-        let path = match path {
-            Some(p) => PathBuf::from(p),
-            None => Self::default_path()?,
+        let candidates = match path {
+            Some(p) => vec![PathBuf::from(p)],
+            None => Self::candidate_paths()?,
         };
 
-        if !path.exists() {
-            anyhow::bail!(
-                "Targets file not found: {:?}. Create it (e.g. from targets.json.example) or pass --targets-file.",
-                path
-            );
-        }
+        let found = candidates.iter().find(|p| p.exists());
+        let path = found.cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Targets file not found. Create it (e.g. from targets.json.example) or pass --targets-file.\nSearched: {:?}",
+                candidates
+            )
+        })?;
 
         let content = fs::read_to_string(&path)
             .await

--- a/targets.toml.example
+++ b/targets.toml.example
@@ -1,0 +1,29 @@
+# Nimbus Targets Example (TOML format)
+
+[targets.dev]
+instance_id = "i-1234567890abcdef0"
+local_port = 5555
+remote_port = 22
+profile = "default"
+region = "ap-northeast-1"
+ssh_user = "ubuntu"
+ssh_identity_file = "~/.ssh/dev.pem"
+ssh_identities_only = true
+
+[targets.prod]
+instance_id = "i-0abcdef0123456789"
+local_port = 5556
+remote_port = 22
+profile = "production"
+region = "ap-northeast-1"
+ssh_user = "ec2-user"
+ssh_identity_file = "~/.ssh/prod.pem"
+ssh_identities_only = true
+
+[targets.internal-alb]
+instance_id = "i-bastion123456789"
+local_port = 10443
+remote_port = 443
+remote_host = "internal-alb-xxx.ap-northeast-1.elb.amazonaws.com"
+profile = "production"
+region = "ap-northeast-1"


### PR DESCRIPTION
## 変更内容

仕様・実装・ドキュメント間の不整合5件を修正。

### 1. `targets.toml.example` 追加
- TOML形式のターゲットファイルサンプルが欠落していた

### 2. `targets.rs`: JSON→TOML 順の探索に修正
- `config.rs` と同様に、デフォルトパスで `targets.json` → `targets.toml` の順に探索するよう変更
- 明示的に `--targets-file` を指定しなくても TOML ファイルが読まれるように

### 3. `docs/CONFIGURATION.md`: diagnostic セクション追記
- `Config` 構造体に存在する `diagnostic` セクション（16項目）がドキュメント未記載だった

### 4. README: `RUST_LOG` → `NIMBUS_LOG_LEVEL` に統一
- 開発セクションで `RUST_LOG=debug` と記載されていたが、アプリ公式の環境変数は `NIMBUS_LOG_LEVEL`

### 5. `Cargo.toml`: `rust-version = "1.70.0"` 追加
- README に「Rust 1.70以上が必要」と記載があるが、Cargo.toml に MSRV が未設定だった