### PR TITLE
chore: remove personal script start-guideline-ssm.sh

### DIFF
--- a/start-guideline-ssm.sh
+++ b/start-guideline-ssm.sh
@@ -1,4 +1,0 @@
-#!/bin/zsh
-
-export PATH="/opt/homebrew/bin:$PATH"
-nimbus connect --target z_guideline


### PR DESCRIPTION
## 概要

個人用の接続スクリプト `start-guideline-ssm.sh` を削除します。

特定のターゲット (`z_guideline`) へのショートカットであり、汎用リポジトリに含めるべきではないファイルです。

Closes #21