### PR TITLE
ci: add Rust build cache with Swatinem/rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           components: clippy
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Lint
         run: cargo clippy -- -D warnings
 
@@ -29,6 +31,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Test
         run: cargo test


### PR DESCRIPTION
## 概要

CI ワークフローの lint / test 両ジョブに `Swatinem/rust-cache@v2` を追加し、依存クレートのビルドキャッシュを有効化します。

## 期待効果

- 依存クレートの再ビルドをスキップ
- CI 実行時間の大幅短縮（初回以降）

Closes #22