### PR TITLE
docs: fix API_REFERENCE.md and DEVELOPMENT.md inconsistencies

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -17,6 +17,19 @@ Nimbus v3.0 の完全な API リファレンスです。このドキュメント
 
 ## CLI コマンド
 
+> **Feature Flags について**
+>
+> 一部のコマンドは Cargo feature flag を有効にしてビルドする必要があります。
+>
+> | Feature Flag | 対象コマンド |
+> |---|---|
+> | `performance-monitoring` | `metrics` |
+> | `persistence` | `database` |
+> | `multi-session` | `multi-session` |
+> | `auto-reconnect` | 自動再接続機能 |
+>
+> すべて有効にするには: `cargo build --features advanced`
+
 ### 基本コマンド
 
 #### `connect` - EC2 インスタンスに接続
@@ -35,9 +48,11 @@ nimbus connect [OPTIONS] (--instance-id <INSTANCE_ID> | --target <NAME>)
 - `--targets-file <PATH>` - targets ファイルのパス（省略時は `~/.config/nimbus/targets.json`）
 - `--local-port, -l <PORT>` - ローカルポート番号 (デフォルト: 8080)
 - `--remote-port, -r <PORT>` - リモートポート番号 (デフォルト: 80)
+- `--remote-host <HOST>` - リモートホスト（踏み台インスタンス経由で内部 ALB 等に接続する場合。`AWS-StartPortForwardingSessionToRemoteHost` を使用）
 - `--profile, -p <PROFILE>` - AWS プロファイル名
 - `--region <REGION>` - AWS リージョン
 - `--priority <PRIORITY>` - セッション優先度 (low, normal, high, critical)
+- `--precheck` - 接続前に予防的チェックを実行
 
 **解決ルール:**
 
@@ -58,8 +73,15 @@ nimbus connect --targets-file ~/.config/nimbus/targets.json --target dev
 # カスタムポートとプロファイル
 nimbus connect -i i-1234567890abcdef0 -l 8080 -r 443 -p production
 
+# リモートホスト経由でポートフォワード（踏み台経由で内部ALB等に接続）
+nimbus connect -i i-1234567890abcdef0 -l 10443 -r 443 \
+  --remote-host internal-alb-xxx.ap-northeast-1.elb.amazonaws.com
+
 # 高優先度セッション
 nimbus connect -i i-1234567890abcdef0 --priority high
+
+# 接続前チェック付き
+nimbus connect -i i-1234567890abcdef0 --precheck
 ```
 
 **戻り値:**
@@ -129,6 +151,8 @@ nimbus tui
 - `Enter` - 選択
 
 #### `multi-session` - マルチセッション管理 UI
+
+> ⚠️ `multi-session` feature flag が必要です（`cargo build --features multi-session`）
 
 ```bash
 nimbus multi-session
@@ -260,6 +284,77 @@ nimbus diagnose interactive [OPTIONS] --instance-id <INSTANCE_ID>
 - 色分け表示
 - 自動更新
 
+##### `precheck` - 接続前チェック（diagnose サブコマンド）
+
+```bash
+nimbus diagnose precheck [OPTIONS] --instance-id <INSTANCE_ID>
+```
+
+**オプション:**
+
+- `--instance-id, -i <ID>` - EC2 インスタンス ID
+- `--local-port <PORT>` - ローカルポート
+- `--profile, -p <PROFILE>` - AWS プロファイル
+- `--region <REGION>` - AWS リージョン
+
+##### `item` - 個別診断項目の実行
+
+```bash
+nimbus diagnose item [OPTIONS] --item <NAME> --instance-id <INSTANCE_ID>
+```
+
+**オプション:**
+
+- `--item, -t <NAME>` - 診断項目名
+- `--instance-id, -i <ID>` - EC2 インスタンス ID
+- `--local-port <PORT>` - ローカルポート
+- `--remote-port <PORT>` - リモートポート
+- `--profile, -p <PROFILE>` - AWS プロファイル
+- `--region <REGION>` - AWS リージョン
+
+##### `list` - 利用可能な診断項目の一覧
+
+```bash
+nimbus diagnose list
+```
+
+##### `aws-config-integrated` - 統合 AWS 設定検証
+
+クロスバリデーションとキャッシュ機能付きの AWS 設定検証を実行します。
+
+```bash
+nimbus diagnose aws-config-integrated [OPTIONS] --instance-id <INSTANCE_ID>
+```
+
+**オプション:**
+
+- `--instance-id, -i <ID>` - EC2 インスタンス ID
+- `--profile, -p <PROFILE>` - AWS プロファイル
+- `--region <REGION>` - AWS リージョン
+- `--include-credentials` - 認証情報検証を含む (デフォルト: true)
+- `--include-iam` - IAM 権限検証を含む (デフォルト: true)
+- `--include-vpc` - VPC 設定検証を含む (デフォルト: true)
+- `--include-security-groups` - セキュリティグループ検証を含む (デフォルト: true)
+- `--minimum-score <SCORE>` - 最低コンプライアンススコア (デフォルト: 75.0)
+- `--clear-cache` - 検証前にキャッシュをクリア (デフォルト: false)
+
+##### `settings` - 診断設定の管理
+
+```bash
+nimbus diagnose settings <SUBCOMMAND>
+```
+
+**サブコマンド:**
+
+- `show` - 現在の診断設定を表示
+- `enable <CHECK_NAME>` - 診断チェックを有効化
+- `disable <CHECK_NAME>` - 診断チェックを無効化
+- `auto-fix --enable [--safe-only]` - 自動修復モードを設定
+- `parallel <true|false>` - 並列実行モードを設定
+- `timeout <SECONDS>` - デフォルトタイムアウトを設定
+- `format <text|json|yaml>` - レポート形式を設定
+- `reset` - デフォルト設定にリセット
+
 #### `precheck` - 接続前チェック
 
 ```bash
@@ -366,6 +461,8 @@ nimbus vscode cleanup [SESSION_ID]
 ### データベース管理コマンド
 
 #### `database` - データベース管理
+
+> ⚠️ `persistence` feature flag が必要です（`cargo build --features persistence`）
 
 ```bash
 nimbus database <SUBCOMMAND>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -85,12 +85,52 @@ cargo build
 # リリースビルド
 cargo build --release
 
+# 全 feature 有効でビルド
+cargo build --features advanced
+
 # テスト
 cargo test
 
 # 実行
 cargo run -- --help
 ```
+
+## プロジェクト構造
+
+```
+src/
+├── main.rs                  # CLI 定義 (clap) とエントリポイント
+├── commands/                # コマンドハンドラ（サブコマンドごとに分割）
+│   ├── mod.rs
+│   ├── connect.rs           # connect コマンド
+│   ├── config.rs            # config サブコマンド
+│   ├── database.rs          # database サブコマンド (persistence feature)
+│   ├── diagnose.rs          # diagnose サブコマンド
+│   ├── diagnostic_settings.rs # diagnose settings サブコマンド
+│   ├── fix.rs               # fix コマンド
+│   ├── monitoring.rs        # metrics / resources / health コマンド
+│   ├── multi_session.rs     # multi-session コマンド (multi-session feature)
+│   ├── tui.rs               # tui コマンド
+│   └── vscode.rs            # vscode サブコマンド
+├── aws.rs                   # AWS SDK ラッパー
+├── config.rs                # 設定ファイル読み込み・検証
+├── targets.rs               # ターゲットファイル (JSON/TOML)
+├── diagnostic.rs            # 診断エンジン
+├── error.rs                 # エラー型定義
+├── error_recovery.rs        # エラー回復・リトライ
+├── user_messages.rs         # ユーザー向けメッセージ
+└── ...                      # その他モジュール
+```
+
+### Feature Flags
+
+| Flag | 説明 |
+|---|---|
+| `performance-monitoring` | パフォーマンス監視 (`monitor`, `performance` モジュール) |
+| `persistence` | データベース永続化 (`persistence` モジュール) |
+| `multi-session` | マルチセッション管理 (`multi_session`, `multi_session_ui` モジュール) |
+| `auto-reconnect` | 自動再接続 (`reconnect` モジュール) |
+| `advanced` | 上記すべてを有効化 |
 
 ## クロスコンパイル（手動）
 


### PR DESCRIPTION
## 概要

API_REFERENCE.md と DEVELOPMENT.md の実装との不整合を修正。

## 変更内容

### API_REFERENCE.md
- `connect` コマンドに `--remote-host`, `--precheck` オプションを追加
- `diagnose` の未記載サブコマンドを追加（`precheck`, `item`, `list`, `aws-config-integrated`, `settings`）
- Feature flags の注記を追加（CLI コマンドセクション冒頭の概要テーブル + 各コマンドの個別注記）

### DEVELOPMENT.md
- `src/commands/` モジュール分割後のプロジェクト構造を追加
- Feature flags テーブルを追加