### PR TITLE
fix(ci): add --all-features to clippy/test and cargo fmt --check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,15 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Format check
+        run: cargo fmt -- --check
+
       - name: Lint
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-features -- -D warnings
 
   test:
     runs-on: ubuntu-latest
@@ -35,4 +38,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Test
-        run: cargo test
+        run: cargo test --all-features


### PR DESCRIPTION
## 概要
Closes #63

CI が `default = []` のみでビルド・テストしていたため、`persistence`, `multi-session`, `auto-reconnect`, `performance-monitoring` 等の feature gate 配下のコードが一切検証されていなかった問題を修正。

## 変更内容
- `cargo clippy` に `--all-features` を追加
- `cargo test` に `--all-features` を追加
- `cargo fmt -- --check` ステップを追加
- `rustfmt` コンポーネントをツールチェインに追加