### PR TITLE
fix: retain WorkerGuard from init_logging to prevent log loss

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::SystemTime;
-use tracing_appender::{non_blocking, rolling};
+use tracing_appender::{non_blocking, non_blocking::WorkerGuard, rolling};
 use tracing_subscriber::{
     fmt::{self, format::FmtSpan},
     layer::SubscriberExt,
@@ -54,11 +54,12 @@ impl Default for LoggingConfig {
 }
 
 /// Initialize logging system
-pub fn init_logging(config: &LoggingConfig) -> Result<(), Box<dyn std::error::Error>> {
+pub fn init_logging(config: &LoggingConfig) -> Result<Option<WorkerGuard>, Box<dyn std::error::Error>> {
     let env_filter = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new(&config.level))?;
 
     let mut layers = Vec::new();
+    let mut guard = None;
 
     // Console layer
     if config.console_enabled {
@@ -86,7 +87,8 @@ pub fn init_logging(config: &LoggingConfig) -> Result<(), Box<dyn std::error::Er
             _ => rolling::never(&config.log_dir, format!("{}.log", config.file_prefix)),
         };
         
-        let (non_blocking, _guard) = non_blocking(file_appender);
+        let (non_blocking, worker_guard) = non_blocking(file_appender);
+        guard = Some(worker_guard);
         
         let file_layer = if config.json_format {
             fmt::layer()
@@ -118,7 +120,7 @@ pub fn init_logging(config: &LoggingConfig) -> Result<(), Box<dyn std::error::Er
         .with(layers)
         .init();
 
-    Ok(())
+    Ok(guard)
 }
 
 /// Structured log entry for errors

--- a/src/main.rs
+++ b/src/main.rs
@@ -644,10 +644,13 @@ async fn main() -> Result<()> {
         performance_tracing: cli.verbose,
     };
 
-    if let Err(e) = crate::logging::init_logging(&logging_config) {
-        eprintln!("Failed to initialize logging: {}", e);
-        return Err(anyhow::anyhow!("Failed to initialize logging: {}", e));
-    }
+    let _guard = match crate::logging::init_logging(&logging_config) {
+        Ok(guard) => guard,
+        Err(e) => {
+            eprintln!("Failed to initialize logging: {}", e);
+            return Err(anyhow::anyhow!("Failed to initialize logging: {}", e));
+        }
+    };
 
     info!("Starting Nimbus v3.0.0");
 


### PR DESCRIPTION
## Summary

Fixes #57

`tracing_appender` の `WorkerGuard` が `init_logging()` 関数のスコープ終了時にドロップされ、非同期ログバッファがフラッシュされずにログが失われるバグを修正。

## Changes

### `src/logging.rs`
- `init_logging` の戻り値を `Result<(), ...>` → `Result<Option<WorkerGuard>, ...>` に変更
- ファイルロギング有効時に `WorkerGuard` を呼び出し元に返すよう修正

### `src/main.rs`
- `init_logging` の戻り値を `_guard` 変数で保持し、`main` 関数の末尾まで生存させるよう変更

## Why `Option<WorkerGuard>`?

ファイルロギングが無効 (`file_enabled: false`) の場合は `WorkerGuard` が生成されないため、`Option` で返す設計としています。