### PR TITLE
fix: remove unnecessary #![allow(dead_code)] from 11 modules

### DIFF
--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1,4 +1,3 @@
-
 use anyhow::{Context, Result};
 use aws_config::{BehaviorVersion, Region};
 use aws_credential_types::Credentials;

--- a/src/instance_diagnostics.rs
+++ b/src/instance_diagnostics.rs
@@ -1,4 +1,3 @@
-
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use aws_sdk_ec2::types::{InstanceStateName, PlatformValues};

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,3 @@
-
 use crate::error::{ErrorSeverity, NimbusError};
 use crate::error_recovery::ContextualError;
 use serde::{Deserialize, Serialize};

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -1,4 +1,3 @@
-
 use crate::aws::{AwsManager, SsmSessionStatus};
 use crate::error::{Result, SessionError};
 use crate::session::{Session, SessionConfig, SessionStatus};

--- a/src/network_diagnostics.rs
+++ b/src/network_diagnostics.rs
@@ -1,4 +1,3 @@
-
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};

--- a/src/port_diagnostics.rs
+++ b/src/port_diagnostics.rs
@@ -1,4 +1,3 @@
-
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src/realtime_feedback.rs
+++ b/src/realtime_feedback.rs
@@ -1,4 +1,3 @@
-
 use crossterm::{
     cursor,
     event::{self, Event, KeyCode, KeyEvent, KeyModifiers},

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,4 +1,3 @@
-
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::time::SystemTime;

--- a/src/ssm_agent_diagnostics.rs
+++ b/src/ssm_agent_diagnostics.rs
@@ -1,4 +1,3 @@
-
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,3 @@
-
 use crate::error::Result;
 use crate::session::Session;
 use crossterm::{

--- a/src/user_messages.rs
+++ b/src/user_messages.rs
@@ -1,4 +1,3 @@
-
 use crate::error::{
     AwsError, ConfigError, ConnectionError, NimbusError, ResourceError, SessionError, UiError,
 };


### PR DESCRIPTION
## 概要
Closes #53

11ファイルに付与されていたモジュールレベルの `#![allow(dead_code)]` を削除。

## 対象ファイル
- `src/manager.rs`
- `src/session.rs`
- `src/aws.rs`
- `src/ui.rs`
- `src/ssm_agent_diagnostics.rs`
- `src/logging.rs`
- `src/user_messages.rs`
- `src/port_diagnostics.rs`
- `src/realtime_feedback.rs`
- `src/network_diagnostics.rs`
- `src/instance_diagnostics.rs`

## 確認結果
削除後に `cargo check --all-features` および `cargo clippy --all-features` を実行し、dead_code 警告がゼロであることを確認。実際には未使用コードは存在せず、すべての `#![allow(dead_code)]` は不要でした。