### PR TITLE
perf: reuse DB connection in SqlitePersistenceManager

### DIFF
--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Utc};
 use rusqlite::{backup::Backup, params, Connection, OptionalExtension, Row};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard};
 use tracing::{debug, info, warn};
 
 /// Database schema version for migration management
@@ -118,12 +119,17 @@ pub trait PersistenceManager {
 /// SQLite implementation of persistence manager
 pub struct SqlitePersistenceManager {
     db_path: PathBuf,
+    conn: Mutex<Connection>,
 }
 
 impl SqlitePersistenceManager {
     /// Create new SQLite persistence manager
-    pub fn new(db_path: PathBuf) -> Self {
-        Self { db_path }
+    pub fn new(db_path: PathBuf) -> Result<Self> {
+        let conn = Self::open_connection(&db_path)?;
+        Ok(Self {
+            db_path,
+            conn: Mutex::new(conn),
+        })
     }
 
     /// Create with default database path
@@ -140,51 +146,32 @@ impl SqlitePersistenceManager {
         std::fs::create_dir_all(&db_dir)?;
         let db_path = db_dir.join("sessions.db");
 
-        Ok(Self::new(db_path))
+        Self::new(db_path)
     }
 
-    /// Get database connection
-    fn get_connection(&self) -> Result<Connection> {
-        let conn = Connection::open(&self.db_path)?;
-
-        // Enable foreign keys - this PRAGMA doesn't return results
+    /// Open and configure a database connection
+    fn open_connection(db_path: &std::path::Path) -> Result<Connection> {
+        let conn = Connection::open(db_path)?;
         conn.execute("PRAGMA foreign_keys = ON", [])?;
-
-        // Set WAL mode - this PRAGMA returns the mode, so we need to use query_row or ignore the result
-        conn.execute("PRAGMA journal_mode = WAL", []).or_else(|e| {
-            match e {
-                rusqlite::Error::ExecuteReturnedResults => {
-                    // This is expected for journal_mode pragma, ignore it
-                    Ok(0)
-                }
-                _ => Err(e),
-            }
-        })?;
-
-        // Set synchronous mode - this might return results too
-        conn.execute("PRAGMA synchronous = NORMAL", [])
-            .or_else(|e| {
-                match e {
-                    rusqlite::Error::ExecuteReturnedResults => {
-                        // This is expected, ignore it
-                        Ok(0)
-                    }
+        for pragma in &[
+            "journal_mode = WAL",
+            "synchronous = NORMAL",
+            "cache_size = 10000",
+        ] {
+            conn.execute(&format!("PRAGMA {pragma}"), [])
+                .or_else(|e| match e {
+                    rusqlite::Error::ExecuteReturnedResults => Ok(0),
                     _ => Err(e),
-                }
-            })?;
-
-        // Set cache size - this might return results too
-        conn.execute("PRAGMA cache_size = 10000", []).or_else(|e| {
-            match e {
-                rusqlite::Error::ExecuteReturnedResults => {
-                    // This is expected, ignore it
-                    Ok(0)
-                }
-                _ => Err(e),
-            }
-        })?;
-
+                })?;
+        }
         Ok(conn)
+    }
+
+    /// Get a lock on the held connection
+    fn conn(&self) -> MutexGuard<'_, Connection> {
+        self.conn
+            .lock()
+            .expect("database connection mutex poisoned")
     }
 
     /// Create database tables
@@ -518,7 +505,7 @@ impl PersistenceManager for SqlitePersistenceManager {
             std::fs::create_dir_all(parent)?;
         }
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
 
         // First create the schema_version table if it doesn't exist
         conn.execute(
@@ -541,7 +528,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn save_session(&self, session: &PersistentSession) -> Result<()> {
         debug!("Saving session: {}", session.session_id);
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         conn.execute(
             "INSERT OR REPLACE INTO sessions 
              (session_id, instance_id, region, status, created_at, last_activity, 
@@ -570,7 +557,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn load_session(&self, session_id: &str) -> Result<Option<PersistentSession>> {
         debug!("Loading session: {}", session_id);
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         let mut stmt = conn.prepare(
             "SELECT session_id, instance_id, region, status, created_at, last_activity, 
                     connection_count, total_duration_seconds, process_id, is_stale, recovery_attempts
@@ -594,7 +581,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn load_active_sessions(&self) -> Result<Vec<PersistentSession>> {
         debug!("Loading active sessions");
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         let mut stmt = conn.prepare(
             "SELECT session_id, instance_id, region, status, created_at, last_activity,
                     connection_count, total_duration_seconds, process_id, is_stale, recovery_attempts
@@ -618,7 +605,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn update_session_status(&self, session_id: &str, status: SessionStatus) -> Result<()> {
         debug!("Updating session status: {} -> {:?}", session_id, status);
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         let rows_affected = conn.execute(
             "UPDATE sessions SET status = ?, last_activity = ? WHERE session_id = ?",
             params![status.to_string(), Utc::now().to_rfc3339(), session_id],
@@ -637,7 +624,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn update_session_activity(&self, session_id: &str) -> Result<()> {
         debug!("Updating session activity: {}", session_id);
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         let rows_affected = conn.execute(
             "UPDATE sessions SET last_activity = ? WHERE session_id = ?",
             params![Utc::now().to_rfc3339(), session_id],
@@ -654,7 +641,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn delete_session(&self, session_id: &str) -> Result<()> {
         debug!("Deleting session: {}", session_id);
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         let rows_affected = conn.execute(
             "DELETE FROM sessions WHERE session_id = ?",
             params![session_id],
@@ -676,7 +663,7 @@ impl PersistenceManager for SqlitePersistenceManager {
             metrics.session_id
         );
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         conn.execute(
             "INSERT INTO performance_metrics 
              (session_id, timestamp, connection_time_ms, latency_ms, throughput_mbps,
@@ -713,7 +700,7 @@ impl PersistenceManager for SqlitePersistenceManager {
             session_id, limit
         );
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         let query = if let Some(limit) = limit {
             format!(
                 "SELECT session_id, timestamp, connection_time_ms, latency_ms, throughput_mbps,
@@ -753,7 +740,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn get_performance_statistics(&self, session_id: &str) -> Result<PerformanceStatistics> {
         debug!("Getting performance statistics for session: {}", session_id);
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         let stats = conn.query_row(
             "SELECT 
                 COUNT(*) as count,
@@ -822,7 +809,7 @@ impl PersistenceManager for SqlitePersistenceManager {
         info!("Cleaning up data older than {} days", retention_days);
 
         let cutoff_date = Utc::now() - chrono::Duration::days(retention_days as i64);
-        let conn = self.get_connection()?;
+        let conn = self.conn();
 
         // Delete old performance metrics
         let metrics_deleted = conn.execute(
@@ -851,7 +838,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn get_database_info(&self) -> Result<DatabaseInfo> {
         debug!("Getting database information");
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
 
         // Get schema version
         let schema_version: i32 = conn
@@ -894,7 +881,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn mark_sessions_as_stale(&self) -> Result<u32> {
         info!("Marking active sessions as potentially stale");
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         let rows_affected = conn.execute(
             "UPDATE sessions SET is_stale = 1 
              WHERE status IN ('Active', 'Connecting', 'Reconnecting')",
@@ -909,7 +896,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn restore_session_state(&self, session_id: &str) -> Result<Option<SessionRecoveryInfo>> {
         debug!("Restoring session state for: {}", session_id);
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         let mut stmt = conn.prepare(
             "SELECT session_id, instance_id, region, status, created_at, last_activity,
                     connection_count, total_duration_seconds, process_id, recovery_attempts
@@ -995,7 +982,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn save_application_state(&self, state: &ApplicationState) -> Result<()> {
         debug!("Saving application state");
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         conn.execute(
             "INSERT OR REPLACE INTO application_state 
              (id, startup_time, last_heartbeat, active_session_count, total_memory_usage_mb, 
@@ -1019,7 +1006,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn load_application_state(&self) -> Result<Option<ApplicationState>> {
         debug!("Loading application state");
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         let state = conn
             .query_row(
                 "SELECT startup_time, last_heartbeat, active_session_count, 
@@ -1078,10 +1065,10 @@ impl PersistenceManager for SqlitePersistenceManager {
         }
 
         // Create backup using SQLite backup API
-        let source_conn = self.get_connection()?;
+        let conn = self.conn();
         let mut backup_conn = Connection::open(backup_path)?;
 
-        let backup = Backup::new(&source_conn, &mut backup_conn)?;
+        let backup = Backup::new(&conn, &mut backup_conn)?;
         backup.run_to_completion(5, std::time::Duration::from_millis(250), None)?;
 
         info!("Database backup completed successfully");
@@ -1113,6 +1100,15 @@ impl PersistenceManager for SqlitePersistenceManager {
 
         let backup = Backup::new(&backup_conn, &mut target_conn)?;
         backup.run_to_completion(5, std::time::Duration::from_millis(250), None)?;
+        drop(backup);
+        drop(target_conn);
+        drop(backup_conn);
+
+        // Reopen held connection to pick up restored data
+        *self
+            .conn
+            .lock()
+            .expect("database connection mutex poisoned") = Self::open_connection(&self.db_path)?;
 
         info!("Database restored from backup successfully");
         Ok(())
@@ -1122,7 +1118,7 @@ impl PersistenceManager for SqlitePersistenceManager {
     async fn validate_integrity(&self) -> Result<IntegrityReport> {
         info!("Validating database integrity");
 
-        let conn = self.get_connection()?;
+        let conn = self.conn();
         let mut issues = Vec::new();
         let mut recommendations = Vec::new();
 


### PR DESCRIPTION
## 概要
Closes #70

`SqlitePersistenceManager` で DB 操作のたびに `Connection::open()` + PRAGMA 4つを実行していたのを、構造体に `Mutex<Connection>` を保持して再利用するように変更。

## 変更内容
- `SqlitePersistenceManager` に `conn: Mutex<Connection>` フィールドを追加
- `get_connection()` (毎回 open) → `conn()` (Mutex lock) に置換
- `open_connection()` static method で接続設定を一元化
- `backup_database` は保持コネクションをソースとして使用
- `restore_from_backup` 後にコネクションを再オープン
- PRAGMA 設定コードを DRY 化

## 効果
- 毎回の `Connection::open()` + ファイルロック取得/解放のオーバーヘッドを排除
- PRAGMA (`foreign_keys`, `journal_mode`, `synchronous`, `cache_size`) の重複実行を排除