### PR TITLE
refactor: remove #[allow(unused_imports)] and unused imports from commands/

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,49 +1,8 @@
-#[allow(unused_imports)]
 use anyhow::Result;
-#[allow(unused_imports)]
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
-#[allow(unused_imports)]
-use super::{
-    ConfigCommands, DatabaseCommands, DiagnosticCommands, DiagnosticSettingsCommands,
-    VsCodeCommands,
-};
-#[allow(unused_imports)]
-use crate::aws_config_validator::{SuggestionCategory, SuggestionPriority};
-#[allow(unused_imports)]
-use crate::diagnostic::{DiagnosticStatus, Severity};
-#[allow(unused_imports)]
-use crate::preventive_check::PreventiveCheckStatus;
-#[allow(unused_imports)]
-use crate::realtime_feedback::{FeedbackConfig, FeedbackStatus};
-#[allow(unused_imports)]
-use crate::resource::ResourceViolation;
-#[allow(unused_imports)]
-use crate::session::{Session, SessionStatus};
-#[allow(unused_imports)]
-use crate::ui::{ResourceMetrics, TerminalUi};
-#[allow(unused_imports)]
-use crate::{
-    auto_fix,
-    aws::AwsManager,
-    aws_config_validator::{AwsConfigValidationConfig, DefaultAwsConfigValidator},
-    config::Config,
-    diagnostic::{DefaultDiagnosticManager, DiagnosticConfig, DiagnosticManager},
-    error::NimbusError,
-    error_recovery::{ContextualError, ErrorContext, ErrorRecoveryManager},
-    health::{DefaultHealthChecker, HealthChecker},
-    logging::StructuredLogger,
-    manager::{DefaultSessionManager, SessionManager},
-    preventive_check::{DefaultPreventiveCheck, PreventiveCheck, PreventiveCheckConfig},
-    resource::ResourceMonitor,
-    session::{SessionConfig, SessionPriority},
-    user_messages::UserMessageSystem,
-    vscode::VsCodeIntegration,
-};
-#[allow(unused_imports)]
-use crate::{
-    aws_config_validator, diagnostic, preventive_check, realtime_feedback, resource, session, ui,
-};
+use super::ConfigCommands;
+use crate::config::Config;
 
 #[allow(dead_code)]
 pub async fn handle_config_validation(_config: &Config) -> Result<()> {

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -1,48 +1,19 @@
-#[allow(unused_imports)]
 use anyhow::Result;
-#[allow(unused_imports)]
 use tracing::{error, info, warn};
 
-#[allow(unused_imports)]
-use super::{
-    ConfigCommands, DatabaseCommands, DiagnosticCommands, DiagnosticSettingsCommands,
-    VsCodeCommands,
-};
-#[allow(unused_imports)]
-use crate::aws_config_validator::{SuggestionCategory, SuggestionPriority};
-#[allow(unused_imports)]
-use crate::diagnostic::{DiagnosticStatus, Severity};
-#[allow(unused_imports)]
-use crate::preventive_check::PreventiveCheckStatus;
-#[allow(unused_imports)]
-use crate::realtime_feedback::{FeedbackConfig, FeedbackStatus};
-#[allow(unused_imports)]
-use crate::resource::ResourceViolation;
-#[allow(unused_imports)]
-use crate::session::{Session, SessionStatus};
-#[allow(unused_imports)]
-use crate::ui::{ResourceMetrics, TerminalUi};
-#[allow(unused_imports)]
+use crate::preventive_check;
 use crate::{
     auto_fix,
     aws::AwsManager,
-    aws_config_validator::{AwsConfigValidationConfig, DefaultAwsConfigValidator},
     config::Config,
-    diagnostic::{DefaultDiagnosticManager, DiagnosticConfig, DiagnosticManager},
     error::NimbusError,
     error_recovery::{ContextualError, ErrorContext, ErrorRecoveryManager},
-    health::{DefaultHealthChecker, HealthChecker},
     logging::StructuredLogger,
     manager::{DefaultSessionManager, SessionManager},
     preventive_check::{DefaultPreventiveCheck, PreventiveCheck, PreventiveCheckConfig},
-    resource::ResourceMonitor,
     session::{SessionConfig, SessionPriority},
     user_messages::UserMessageSystem,
     vscode::VsCodeIntegration,
-};
-#[allow(unused_imports)]
-use crate::{
-    aws_config_validator, diagnostic, preventive_check, realtime_feedback, resource, session, ui,
 };
 
 /// Generic recovery wrapper that eliminates duplicated error-handling logic.

--- a/src/commands/database.rs
+++ b/src/commands/database.rs
@@ -1,49 +1,8 @@
-#[allow(unused_imports)]
 use anyhow::Result;
-#[allow(unused_imports)]
 use tracing::{error, info, warn};
 
-#[allow(unused_imports)]
-use super::{
-    ConfigCommands, DatabaseCommands, DiagnosticCommands, DiagnosticSettingsCommands,
-    VsCodeCommands,
-};
-#[allow(unused_imports)]
-use crate::aws_config_validator::{SuggestionCategory, SuggestionPriority};
-#[allow(unused_imports)]
-use crate::diagnostic::{DiagnosticStatus, Severity};
-#[allow(unused_imports)]
-use crate::preventive_check::PreventiveCheckStatus;
-#[allow(unused_imports)]
-use crate::realtime_feedback::{FeedbackConfig, FeedbackStatus};
-#[allow(unused_imports)]
-use crate::resource::ResourceViolation;
-#[allow(unused_imports)]
-use crate::session::{Session, SessionStatus};
-#[allow(unused_imports)]
-use crate::ui::{ResourceMetrics, TerminalUi};
-#[allow(unused_imports)]
-use crate::{
-    auto_fix,
-    aws::AwsManager,
-    aws_config_validator::{AwsConfigValidationConfig, DefaultAwsConfigValidator},
-    config::Config,
-    diagnostic::{DefaultDiagnosticManager, DiagnosticConfig, DiagnosticManager},
-    error::NimbusError,
-    error_recovery::{ContextualError, ErrorContext, ErrorRecoveryManager},
-    health::{DefaultHealthChecker, HealthChecker},
-    logging::StructuredLogger,
-    manager::{DefaultSessionManager, SessionManager},
-    preventive_check::{DefaultPreventiveCheck, PreventiveCheck, PreventiveCheckConfig},
-    resource::ResourceMonitor,
-    session::{SessionConfig, SessionPriority},
-    user_messages::UserMessageSystem,
-    vscode::VsCodeIntegration,
-};
-#[allow(unused_imports)]
-use crate::{
-    aws_config_validator, diagnostic, preventive_check, realtime_feedback, resource, session, ui,
-};
+use super::DatabaseCommands;
+use crate::config::Config;
 
 use crate::persistence::{PersistenceManager, SqlitePersistenceManager};
 

--- a/src/commands/diagnose.rs
+++ b/src/commands/diagnose.rs
@@ -1,48 +1,13 @@
-#[allow(unused_imports)]
 use anyhow::Result;
-#[allow(unused_imports)]
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
-#[allow(unused_imports)]
-use super::{
-    ConfigCommands, DatabaseCommands, DiagnosticCommands, DiagnosticSettingsCommands,
-    VsCodeCommands,
-};
-#[allow(unused_imports)]
-use crate::aws_config_validator::{SuggestionCategory, SuggestionPriority};
-#[allow(unused_imports)]
-use crate::diagnostic::{DiagnosticStatus, Severity};
-#[allow(unused_imports)]
-use crate::preventive_check::PreventiveCheckStatus;
-#[allow(unused_imports)]
-use crate::realtime_feedback::{FeedbackConfig, FeedbackStatus};
-#[allow(unused_imports)]
-use crate::resource::ResourceViolation;
-#[allow(unused_imports)]
-use crate::session::{Session, SessionStatus};
-#[allow(unused_imports)]
-use crate::ui::{ResourceMetrics, TerminalUi};
-#[allow(unused_imports)]
+use super::DiagnosticCommands;
+use crate::{aws_config_validator, diagnostic, preventive_check, realtime_feedback};
 use crate::{
-    auto_fix,
-    aws::AwsManager,
     aws_config_validator::{AwsConfigValidationConfig, DefaultAwsConfigValidator},
     config::Config,
     diagnostic::{DefaultDiagnosticManager, DiagnosticConfig, DiagnosticManager},
-    error::NimbusError,
-    error_recovery::{ContextualError, ErrorContext, ErrorRecoveryManager},
-    health::{DefaultHealthChecker, HealthChecker},
-    logging::StructuredLogger,
-    manager::{DefaultSessionManager, SessionManager},
     preventive_check::{DefaultPreventiveCheck, PreventiveCheck, PreventiveCheckConfig},
-    resource::ResourceMonitor,
-    session::{SessionConfig, SessionPriority},
-    user_messages::UserMessageSystem,
-    vscode::VsCodeIntegration,
-};
-#[allow(unused_imports)]
-use crate::{
-    aws_config_validator, diagnostic, preventive_check, realtime_feedback, resource, session, ui,
 };
 
 pub async fn handle_diagnose(action: DiagnosticCommands, _config: &Config) -> Result<()> {

--- a/src/commands/diagnostic_settings.rs
+++ b/src/commands/diagnostic_settings.rs
@@ -1,49 +1,8 @@
-#[allow(unused_imports)]
 use anyhow::Result;
-#[allow(unused_imports)]
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
-#[allow(unused_imports)]
-use super::{
-    ConfigCommands, DatabaseCommands, DiagnosticCommands, DiagnosticSettingsCommands,
-    VsCodeCommands,
-};
-#[allow(unused_imports)]
-use crate::aws_config_validator::{SuggestionCategory, SuggestionPriority};
-#[allow(unused_imports)]
-use crate::diagnostic::{DiagnosticStatus, Severity};
-#[allow(unused_imports)]
-use crate::preventive_check::PreventiveCheckStatus;
-#[allow(unused_imports)]
-use crate::realtime_feedback::{FeedbackConfig, FeedbackStatus};
-#[allow(unused_imports)]
-use crate::resource::ResourceViolation;
-#[allow(unused_imports)]
-use crate::session::{Session, SessionStatus};
-#[allow(unused_imports)]
-use crate::ui::{ResourceMetrics, TerminalUi};
-#[allow(unused_imports)]
-use crate::{
-    auto_fix,
-    aws::AwsManager,
-    aws_config_validator::{AwsConfigValidationConfig, DefaultAwsConfigValidator},
-    config::Config,
-    diagnostic::{DefaultDiagnosticManager, DiagnosticConfig, DiagnosticManager},
-    error::NimbusError,
-    error_recovery::{ContextualError, ErrorContext, ErrorRecoveryManager},
-    health::{DefaultHealthChecker, HealthChecker},
-    logging::StructuredLogger,
-    manager::{DefaultSessionManager, SessionManager},
-    preventive_check::{DefaultPreventiveCheck, PreventiveCheck, PreventiveCheckConfig},
-    resource::ResourceMonitor,
-    session::{SessionConfig, SessionPriority},
-    user_messages::UserMessageSystem,
-    vscode::VsCodeIntegration,
-};
-#[allow(unused_imports)]
-use crate::{
-    aws_config_validator, diagnostic, preventive_check, realtime_feedback, resource, session, ui,
-};
+use super::DiagnosticSettingsCommands;
+use crate::config::Config;
 
 pub async fn handle_diagnostic_settings(
     action: DiagnosticSettingsCommands,

--- a/src/commands/fix.rs
+++ b/src/commands/fix.rs
@@ -1,48 +1,11 @@
-#[allow(unused_imports)]
 use anyhow::Result;
-#[allow(unused_imports)]
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
-#[allow(unused_imports)]
-use super::{
-    ConfigCommands, DatabaseCommands, DiagnosticCommands, DiagnosticSettingsCommands,
-    VsCodeCommands,
-};
-#[allow(unused_imports)]
-use crate::aws_config_validator::{SuggestionCategory, SuggestionPriority};
-#[allow(unused_imports)]
-use crate::diagnostic::{DiagnosticStatus, Severity};
-#[allow(unused_imports)]
-use crate::preventive_check::PreventiveCheckStatus;
-#[allow(unused_imports)]
-use crate::realtime_feedback::{FeedbackConfig, FeedbackStatus};
-#[allow(unused_imports)]
-use crate::resource::ResourceViolation;
-#[allow(unused_imports)]
-use crate::session::{Session, SessionStatus};
-#[allow(unused_imports)]
-use crate::ui::{ResourceMetrics, TerminalUi};
-#[allow(unused_imports)]
+use crate::diagnostic;
 use crate::{
     auto_fix,
-    aws::AwsManager,
-    aws_config_validator::{AwsConfigValidationConfig, DefaultAwsConfigValidator},
     config::Config,
     diagnostic::{DefaultDiagnosticManager, DiagnosticConfig, DiagnosticManager},
-    error::NimbusError,
-    error_recovery::{ContextualError, ErrorContext, ErrorRecoveryManager},
-    health::{DefaultHealthChecker, HealthChecker},
-    logging::StructuredLogger,
-    manager::{DefaultSessionManager, SessionManager},
-    preventive_check::{DefaultPreventiveCheck, PreventiveCheck, PreventiveCheckConfig},
-    resource::ResourceMonitor,
-    session::{SessionConfig, SessionPriority},
-    user_messages::UserMessageSystem,
-    vscode::VsCodeIntegration,
-};
-#[allow(unused_imports)]
-use crate::{
-    aws_config_validator, diagnostic, preventive_check, realtime_feedback, resource, session, ui,
 };
 
 #[allow(clippy::too_many_arguments)]

--- a/src/commands/monitoring.rs
+++ b/src/commands/monitoring.rs
@@ -1,48 +1,11 @@
-#[allow(unused_imports)]
 use anyhow::Result;
-#[allow(unused_imports)]
 use tracing::{error, info, warn};
 
-#[allow(unused_imports)]
-use super::{
-    ConfigCommands, DatabaseCommands, DiagnosticCommands, DiagnosticSettingsCommands,
-    VsCodeCommands,
-};
-#[allow(unused_imports)]
-use crate::aws_config_validator::{SuggestionCategory, SuggestionPriority};
-#[allow(unused_imports)]
-use crate::diagnostic::{DiagnosticStatus, Severity};
-#[allow(unused_imports)]
-use crate::preventive_check::PreventiveCheckStatus;
-#[allow(unused_imports)]
-use crate::realtime_feedback::{FeedbackConfig, FeedbackStatus};
-#[allow(unused_imports)]
-use crate::resource::ResourceViolation;
-#[allow(unused_imports)]
-use crate::session::{Session, SessionStatus};
-#[allow(unused_imports)]
-use crate::ui::{ResourceMetrics, TerminalUi};
-#[allow(unused_imports)]
+use crate::resource;
 use crate::{
-    auto_fix,
-    aws::AwsManager,
-    aws_config_validator::{AwsConfigValidationConfig, DefaultAwsConfigValidator},
     config::Config,
-    diagnostic::{DefaultDiagnosticManager, DiagnosticConfig, DiagnosticManager},
-    error::NimbusError,
-    error_recovery::{ContextualError, ErrorContext, ErrorRecoveryManager},
     health::{DefaultHealthChecker, HealthChecker},
-    logging::StructuredLogger,
-    manager::{DefaultSessionManager, SessionManager},
-    preventive_check::{DefaultPreventiveCheck, PreventiveCheck, PreventiveCheckConfig},
     resource::ResourceMonitor,
-    session::{SessionConfig, SessionPriority},
-    user_messages::UserMessageSystem,
-    vscode::VsCodeIntegration,
-};
-#[allow(unused_imports)]
-use crate::{
-    aws_config_validator, diagnostic, preventive_check, realtime_feedback, resource, session, ui,
 };
 
 pub async fn handle_metrics(_config: &Config) -> Result<()> {

--- a/src/commands/multi_session.rs
+++ b/src/commands/multi_session.rs
@@ -1,49 +1,7 @@
-#[allow(unused_imports)]
 use anyhow::Result;
-#[allow(unused_imports)]
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
-#[allow(unused_imports)]
-use super::{
-    ConfigCommands, DatabaseCommands, DiagnosticCommands, DiagnosticSettingsCommands,
-    VsCodeCommands,
-};
-#[allow(unused_imports)]
-use crate::aws_config_validator::{SuggestionCategory, SuggestionPriority};
-#[allow(unused_imports)]
-use crate::diagnostic::{DiagnosticStatus, Severity};
-#[allow(unused_imports)]
-use crate::preventive_check::PreventiveCheckStatus;
-#[allow(unused_imports)]
-use crate::realtime_feedback::{FeedbackConfig, FeedbackStatus};
-#[allow(unused_imports)]
-use crate::resource::ResourceViolation;
-#[allow(unused_imports)]
-use crate::session::{Session, SessionStatus};
-#[allow(unused_imports)]
-use crate::ui::{ResourceMetrics, TerminalUi};
-#[allow(unused_imports)]
-use crate::{
-    auto_fix,
-    aws::AwsManager,
-    aws_config_validator::{AwsConfigValidationConfig, DefaultAwsConfigValidator},
-    config::Config,
-    diagnostic::{DefaultDiagnosticManager, DiagnosticConfig, DiagnosticManager},
-    error::NimbusError,
-    error_recovery::{ContextualError, ErrorContext, ErrorRecoveryManager},
-    health::{DefaultHealthChecker, HealthChecker},
-    logging::StructuredLogger,
-    manager::{DefaultSessionManager, SessionManager},
-    preventive_check::{DefaultPreventiveCheck, PreventiveCheck, PreventiveCheckConfig},
-    resource::ResourceMonitor,
-    session::{SessionConfig, SessionPriority},
-    user_messages::UserMessageSystem,
-    vscode::VsCodeIntegration,
-};
-#[allow(unused_imports)]
-use crate::{
-    aws_config_validator, diagnostic, preventive_check, realtime_feedback, resource, session, ui,
-};
+use crate::{config::Config, error::NimbusError, manager::DefaultSessionManager};
 
 #[cfg(feature = "performance-monitoring")]
 use crate::monitor::DefaultSessionMonitor;
@@ -51,9 +9,6 @@ use crate::monitor::DefaultSessionMonitor;
 use crate::multi_session::{MultiSessionManager, ResourceThresholds};
 #[cfg(feature = "multi-session")]
 use crate::multi_session_ui::MultiSessionUi;
-#[cfg(feature = "persistence")]
-#[allow(unused_imports)]
-use crate::persistence::{PersistenceManager, SqlitePersistenceManager};
 
 #[cfg(feature = "multi-session")]
 pub async fn handle_multi_session(_config: &Config) -> Result<()> {

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -1,49 +1,8 @@
-#[allow(unused_imports)]
 use anyhow::Result;
-#[allow(unused_imports)]
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
-#[allow(unused_imports)]
-use super::{
-    ConfigCommands, DatabaseCommands, DiagnosticCommands, DiagnosticSettingsCommands,
-    VsCodeCommands,
-};
-#[allow(unused_imports)]
-use crate::aws_config_validator::{SuggestionCategory, SuggestionPriority};
-#[allow(unused_imports)]
-use crate::diagnostic::{DiagnosticStatus, Severity};
-#[allow(unused_imports)]
-use crate::preventive_check::PreventiveCheckStatus;
-#[allow(unused_imports)]
-use crate::realtime_feedback::{FeedbackConfig, FeedbackStatus};
-#[allow(unused_imports)]
-use crate::resource::ResourceViolation;
-#[allow(unused_imports)]
-use crate::session::{Session, SessionStatus};
-#[allow(unused_imports)]
-use crate::ui::{ResourceMetrics, TerminalUi};
-#[allow(unused_imports)]
-use crate::{
-    auto_fix,
-    aws::AwsManager,
-    aws_config_validator::{AwsConfigValidationConfig, DefaultAwsConfigValidator},
-    config::Config,
-    diagnostic::{DefaultDiagnosticManager, DiagnosticConfig, DiagnosticManager},
-    error::NimbusError,
-    error_recovery::{ContextualError, ErrorContext, ErrorRecoveryManager},
-    health::{DefaultHealthChecker, HealthChecker},
-    logging::StructuredLogger,
-    manager::{DefaultSessionManager, SessionManager},
-    preventive_check::{DefaultPreventiveCheck, PreventiveCheck, PreventiveCheckConfig},
-    resource::ResourceMonitor,
-    session::{SessionConfig, SessionPriority},
-    user_messages::UserMessageSystem,
-    vscode::VsCodeIntegration,
-};
-#[allow(unused_imports)]
-use crate::{
-    aws_config_validator, diagnostic, preventive_check, realtime_feedback, resource, session, ui,
-};
+use crate::config::Config;
+use crate::{session, ui};
 
 pub async fn handle_tui(_config: &Config) -> Result<()> {
     info!("Launching Terminal UI");

--- a/src/commands/vscode.rs
+++ b/src/commands/vscode.rs
@@ -1,49 +1,8 @@
-#[allow(unused_imports)]
 use anyhow::Result;
-#[allow(unused_imports)]
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
-#[allow(unused_imports)]
-use super::{
-    ConfigCommands, DatabaseCommands, DiagnosticCommands, DiagnosticSettingsCommands,
-    VsCodeCommands,
-};
-#[allow(unused_imports)]
-use crate::aws_config_validator::{SuggestionCategory, SuggestionPriority};
-#[allow(unused_imports)]
-use crate::diagnostic::{DiagnosticStatus, Severity};
-#[allow(unused_imports)]
-use crate::preventive_check::PreventiveCheckStatus;
-#[allow(unused_imports)]
-use crate::realtime_feedback::{FeedbackConfig, FeedbackStatus};
-#[allow(unused_imports)]
-use crate::resource::ResourceViolation;
-#[allow(unused_imports)]
-use crate::session::{Session, SessionStatus};
-#[allow(unused_imports)]
-use crate::ui::{ResourceMetrics, TerminalUi};
-#[allow(unused_imports)]
-use crate::{
-    auto_fix,
-    aws::AwsManager,
-    aws_config_validator::{AwsConfigValidationConfig, DefaultAwsConfigValidator},
-    config::Config,
-    diagnostic::{DefaultDiagnosticManager, DiagnosticConfig, DiagnosticManager},
-    error::NimbusError,
-    error_recovery::{ContextualError, ErrorContext, ErrorRecoveryManager},
-    health::{DefaultHealthChecker, HealthChecker},
-    logging::StructuredLogger,
-    manager::{DefaultSessionManager, SessionManager},
-    preventive_check::{DefaultPreventiveCheck, PreventiveCheck, PreventiveCheckConfig},
-    resource::ResourceMonitor,
-    session::{SessionConfig, SessionPriority},
-    user_messages::UserMessageSystem,
-    vscode::VsCodeIntegration,
-};
-#[allow(unused_imports)]
-use crate::{
-    aws_config_validator, diagnostic, preventive_check, realtime_feedback, resource, session, ui,
-};
+use super::VsCodeCommands;
+use crate::config::Config;
 
 pub async fn handle_vscode(action: VsCodeCommands, config: &Config) -> Result<()> {
     use crate::session;


### PR DESCRIPTION
## 概要

`src/commands/` 配下の全10ファイルで `#[allow(unused_imports)]` 付きでコピペされていた共通 import ブロックを整理し、各ファイルが実際に使用する import のみに絞りました。

Closes #65

## 変更内容

- 全10ファイルから `#[allow(unused_imports)]` アトリビュートを削除（121箇所）
- `cargo fix` により未使用 import を自動除去（108箇所）
- `cargo fmt` でフォーマット整形

### 対象ファイル
- `src/commands/connect.rs`
- `src/commands/config.rs`
- `src/commands/database.rs`
- `src/commands/diagnose.rs`
- `src/commands/diagnostic_settings.rs`
- `src/commands/fix.rs`
- `src/commands/monitoring.rs`
- `src/commands/multi_session.rs`
- `src/commands/tui.rs`
- `src/commands/vscode.rs`

## 動作への影響

import の整理のみで、ロジックの変更はありません。全61テストパス。