### PR TITLE
fix: remove empty ResourceError/UiError enums and dead code

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,12 +15,6 @@ pub enum NimbusError {
     #[error("Connection error: {0}")]
     Connection(ConnectionError),
 
-    #[error("Resource error: {0}")]
-    Resource(ResourceError),
-
-    #[error("UI error: {0}")]
-    Ui(UiError),
-
     #[error("VS Code integration error: {0}")]
     VsCode(VsCodeError),
 
@@ -96,14 +90,6 @@ pub enum ConnectionError {
     PreventiveCheckFailed { reason: String, issues: Vec<String> },
 }
 
-/// Resource management errors
-#[derive(Error, Debug, Clone)]
-pub enum ResourceError {}
-
-/// UI-related errors
-#[derive(Error, Debug, Clone)]
-pub enum UiError {}
-
 /// VS Code integration errors
 #[derive(Error, Debug, Clone)]
 pub enum VsCodeError {
@@ -142,18 +128,6 @@ impl From<SessionError> for NimbusError {
 impl From<ConnectionError> for NimbusError {
     fn from(err: ConnectionError) -> Self {
         NimbusError::Connection(err)
-    }
-}
-
-impl From<ResourceError> for NimbusError {
-    fn from(err: ResourceError) -> Self {
-        NimbusError::Resource(err)
-    }
-}
-
-impl From<UiError> for NimbusError {
-    fn from(err: UiError) -> Self {
-        NimbusError::Ui(err)
     }
 }
 
@@ -209,10 +183,8 @@ impl NimbusError {
         match self {
             NimbusError::Config(_) => ErrorSeverity::High,
             NimbusError::Aws(AwsError::AuthenticationFailed { .. }) => ErrorSeverity::High,
-            NimbusError::Resource(_) => ErrorSeverity::High,
             NimbusError::Connection(_) => ErrorSeverity::Medium,
             NimbusError::Session(_) => ErrorSeverity::Medium,
-            NimbusError::Ui(_) => ErrorSeverity::Low,
             _ => ErrorSeverity::Medium,
         }
     }
@@ -240,7 +212,6 @@ impl NimbusError {
 /// Error severity levels
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorSeverity {
-    Low,
     Medium,
     High,
 }
@@ -248,7 +219,6 @@ pub enum ErrorSeverity {
 impl ErrorSeverity {
     pub fn as_str(&self) -> &'static str {
         match self {
-            ErrorSeverity::Low => "LOW",
             ErrorSeverity::Medium => "MEDIUM",
             ErrorSeverity::High => "HIGH",
         }

--- a/src/error_recovery.rs
+++ b/src/error_recovery.rs
@@ -32,8 +32,6 @@ pub enum RecoveryStrategy {
     Retry(RecoveryConfig),
     /// Fallback to alternative method
     Fallback,
-    /// Graceful degradation
-    Degrade,
     /// Fail immediately
     Fail,
 }
@@ -65,12 +63,6 @@ impl ErrorRecoveryManager {
             // Configuration errors - try fallback
             NimbusError::Config(_) => RecoveryStrategy::Fallback,
 
-            // Resource errors - graceful degradation
-            NimbusError::Resource(_) => RecoveryStrategy::Degrade,
-
-            // UI errors - graceful degradation
-            NimbusError::Ui(_) => RecoveryStrategy::Degrade,
-
             // Critical errors - fail immediately
             _ => RecoveryStrategy::Fail,
         }
@@ -89,10 +81,6 @@ impl ErrorRecoveryManager {
             RecoveryStrategy::Fallback => {
                 warn!("Attempting fallback recovery for error: {}", error);
                 self.attempt_fallback_recovery(operation, error).await
-            }
-            RecoveryStrategy::Degrade => {
-                warn!("Graceful degradation for error: {}", error);
-                self.attempt_graceful_degradation(operation, error).await
             }
             RecoveryStrategy::Fail => {
                 error!("Non-recoverable error: {}", error);
@@ -157,124 +145,6 @@ impl ErrorRecoveryManager {
                             warn!(
                                 "Simple fallback retry attempt {} failed: {}",
                                 attempt, fallback_error
-                            );
-                            if attempt < 2 {
-                                sleep(Duration::from_millis(200)).await;
-                            }
-                        }
-                    }
-                }
-
-                Err(error.clone())
-            }
-        }
-    }
-
-    /// Attempt graceful degradation
-    async fn attempt_graceful_degradation<F, T>(
-        &self,
-        operation: F,
-        error: &NimbusError,
-    ) -> Result<T>
-    where
-        F: Fn() -> Result<T> + Send + Sync,
-        T: Send,
-    {
-        match error {
-            // Resource errors - try with reduced functionality
-            NimbusError::Resource(resource_error) => {
-                info!(
-                    "Attempting graceful degradation for resource error: {}",
-                    resource_error
-                );
-
-                // Wait for resources to potentially free up
-                sleep(Duration::from_secs(1)).await;
-
-                // Try operation again (assuming it will use reduced resources).
-                // If it still fails, do one more attempt after a brief delay.
-                for attempt in 1..=2u32 {
-                    match operation() {
-                        Ok(result) => {
-                            info!(
-                                "Graceful degradation successful - operating with reduced functionality (attempt {})",
-                                attempt
-                            );
-                            return Ok(result);
-                        }
-                        Err(degraded_error) => {
-                            warn!(
-                                "Graceful degradation attempt {} failed: {}",
-                                attempt, degraded_error
-                            );
-                            if attempt < 2 {
-                                sleep(Duration::from_millis(200)).await;
-                            }
-                        }
-                    }
-                }
-
-                Err(error.clone())
-            }
-
-            // UI errors - continue without UI enhancements
-            NimbusError::Ui(ui_error) => {
-                info!(
-                    "Graceful degradation for UI error: {} - continuing without enhanced UI",
-                    ui_error
-                );
-
-                // For UI errors, we might want to continue with basic functionality
-                // This is a placeholder - in a real implementation, we'd set a flag
-                // to disable UI enhancements and retry
-                sleep(Duration::from_millis(100)).await;
-
-                match operation() {
-                    Ok(result) => {
-                        info!("Continuing with basic UI functionality");
-                        Ok(result)
-                    }
-                    Err(_) => {
-                        warn!("Even basic functionality failed");
-                        Err(error.clone())
-                    }
-                }
-            }
-
-            // VS Code errors - continue without VS Code integration
-            NimbusError::VsCode(vscode_error) => {
-                info!("Graceful degradation for VS Code error: {} - continuing without VS Code integration", vscode_error);
-
-                // VS Code integration is optional, so we can continue without it
-                sleep(Duration::from_millis(100)).await;
-
-                match operation() {
-                    Ok(result) => {
-                        info!("Continuing without VS Code integration");
-                        Ok(result)
-                    }
-                    Err(_) => {
-                        warn!("Core functionality failed even without VS Code integration");
-                        Err(error.clone())
-                    }
-                }
-            }
-
-            // For other errors, try a conservative retry
-            _ => {
-                info!("Attempting conservative retry for: {}", error);
-                sleep(Duration::from_millis(1000)).await;
-
-                for attempt in 1..=2u32 {
-                    match operation() {
-                        Ok(result) => {
-                            info!("Conservative retry successful (attempt {})", attempt);
-                            return Ok(result);
-                        }
-                        Err(retry_error) => {
-                            warn!(
-                                "Conservative retry attempt {} failed: {}",
-                                attempt, retry_error
                             );
                             if attempt < 2 {
                                 sleep(Duration::from_millis(200)).await;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -157,7 +157,6 @@ impl ErrorLogEntry {
         Self {
             timestamp: error.context.timestamp,
             level: match error.severity() {
-                ErrorSeverity::Low => "WARN".to_string(),
                 ErrorSeverity::Medium => "ERROR".to_string(),
                 ErrorSeverity::High => "ERROR".to_string(),
             },
@@ -185,18 +184,6 @@ impl StructuredLogger {
         let entry = ErrorLogEntry::from_contextual_error(error);
 
         match error.severity() {
-            ErrorSeverity::Low => {
-                tracing::warn!(
-                    error_type = %entry.error_type,
-                    component = %entry.component,
-                    operation = %entry.operation,
-                    session_id = ?entry.session_id,
-                    instance_id = ?entry.instance_id,
-                    recoverable = %entry.recoverable,
-                    "{}",
-                    entry.error_message
-                );
-            }
             ErrorSeverity::Medium => {
                 tracing::error!(
                     error_type = %entry.error_type,

--- a/src/user_messages.rs
+++ b/src/user_messages.rs
@@ -1,6 +1,4 @@
-use crate::error::{
-    AwsError, ConfigError, ConnectionError, NimbusError, ResourceError, SessionError, UiError,
-};
+use crate::error::{AwsError, ConfigError, ConnectionError, NimbusError, SessionError};
 use std::collections::HashMap;
 
 /// User-friendly error messages and help system
@@ -28,8 +26,6 @@ impl UserMessageSystem {
             NimbusError::Connection(connection_error) => {
                 self.handle_connection_error(connection_error)
             }
-            NimbusError::Resource(resource_error) => self.handle_resource_error(resource_error),
-            NimbusError::Ui(ui_error) => self.handle_ui_error(ui_error),
             _ => UserErrorMessage {
                 title: "予期しないエラー".to_string(),
                 message: error.to_string(),
@@ -172,26 +168,6 @@ impl UserMessageSystem {
                 solutions: issues.clone(),
                 help_command: Some("nimbus diagnose".to_string()),
             },
-        }
-    }
-
-    fn handle_resource_error(&self, _error: &ResourceError) -> UserErrorMessage {
-        UserErrorMessage {
-            title: "リソースエラー".to_string(),
-            message: "リソースに問題があります".to_string(),
-            severity: "medium".to_string(),
-            solutions: vec!["システムリソースを確認してください".to_string()],
-            help_command: None,
-        }
-    }
-
-    fn handle_ui_error(&self, _error: &UiError) -> UserErrorMessage {
-        UserErrorMessage {
-            title: "UIエラー".to_string(),
-            message: "UI処理中にエラーが発生しました".to_string(),
-            severity: "low".to_string(),
-            solutions: vec!["アプリケーションを再起動してください".to_string()],
-            help_command: None,
         }
     }
 


### PR DESCRIPTION
## 概要

`ResourceError` と `UiError` が variant を持たない空 enum であり、インスタンス化不可能なため到達不能コードが発生していた問題を修正。

Closes #55

## 変更内容

### 削除したもの
- `ResourceError` / `UiError` enum 定義
- `NimbusError::Resource` / `NimbusError::Ui` variant
- 対応する `From` impl
- `ErrorSeverity::Low`（`UiError` 削除により未使用化）
- `RecoveryStrategy::Degrade` + `attempt_graceful_degradation`（`ResourceError`/`UiError` 削除により未使用化）

### 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `src/error.rs` | enum 定義・variant・From impl・severity match arm 削除 |
| `src/user_messages.rs` | import・match arm・handler メソッド削除 |
| `src/error_recovery.rs` | match arm・Degrade variant・degradation メソッド削除 |
| `src/logging.rs` | `ErrorSeverity::Low` match arm 削除 |

## 動作への影響

- `ConfigError` は `Invalid` variant を持つため影響なし（削除対象外）
- 削除した enum は空であり実際にインスタンス化されていなかったため、実行時の動作変更なし
- テスト 61 件全パス