### PR TITLE
fix: include error details in handle_resource_error and handle_ui_error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -106,6 +106,16 @@ pub enum VsCodeError {
     ConfigurationError { message: String },
 }
 
+/// Resource-related errors
+#[derive(Error, Debug, Clone)]
+#[allow(dead_code)]
+pub enum ResourceError {}
+
+/// UI-related errors
+#[derive(Error, Debug, Clone)]
+#[allow(dead_code)]
+pub enum UiError {}
+
 /// Result type alias for Nimbus operations
 pub type Result<T> = std::result::Result<T, NimbusError>;
 

--- a/src/user_messages.rs
+++ b/src/user_messages.rs
@@ -175,20 +175,20 @@ impl UserMessageSystem {
         }
     }
 
-    fn handle_resource_error(&self, _error: &ResourceError) -> UserErrorMessage {
+    fn handle_resource_error(&self, error: &ResourceError) -> UserErrorMessage {
         UserErrorMessage {
             title: "リソースエラー".to_string(),
-            message: "リソースに問題があります".to_string(),
+            message: format!("リソースに問題があります: {}", error),
             severity: "medium".to_string(),
             solutions: vec!["システムリソースを確認してください".to_string()],
             help_command: None,
         }
     }
 
-    fn handle_ui_error(&self, _error: &UiError) -> UserErrorMessage {
+    fn handle_ui_error(&self, error: &UiError) -> UserErrorMessage {
         UserErrorMessage {
             title: "UIエラー".to_string(),
-            message: "UI処理中にエラーが発生しました".to_string(),
+            message: format!("UI処理中にエラーが発生しました: {}", error),
             severity: "low".to_string(),
             solutions: vec!["アプリケーションを再起動してください".to_string()],
             help_command: None,

--- a/src/user_messages.rs
+++ b/src/user_messages.rs
@@ -1,4 +1,6 @@
-use crate::error::{AwsError, ConfigError, ConnectionError, NimbusError, SessionError};
+use crate::error::{
+    AwsError, ConfigError, ConnectionError, NimbusError, ResourceError, SessionError, UiError,
+};
 use std::collections::HashMap;
 
 /// User-friendly error messages and help system
@@ -171,6 +173,7 @@ impl UserMessageSystem {
         }
     }
 
+    #[allow(dead_code)]
     fn handle_resource_error(&self, error: &ResourceError) -> UserErrorMessage {
         UserErrorMessage {
             title: "リソースエラー".to_string(),
@@ -181,6 +184,7 @@ impl UserMessageSystem {
         }
     }
 
+    #[allow(dead_code)]
     fn handle_ui_error(&self, error: &UiError) -> UserErrorMessage {
         UserErrorMessage {
             title: "UIエラー".to_string(),


### PR DESCRIPTION
## 概要

`handle_resource_error` と `handle_ui_error` が引数のエラー情報を無視し（`_error`）、固定メッセージを返していた問題を修正。

Closes #128

## 変更内容

- `handle_resource_error`: `_error` → `error` に変更し、`format!("リソースに問題があります: {}", error)` でエラー詳細を含める
- `handle_ui_error`: 同様に `format!("UI処理中にエラーが発生しました: {}", error)` に変更

## 動作への影響

現時点では `ResourceError` / `UiError` は空 enum のため到達不能だが、将来 variant が追加された際にエラー詳細がユーザーに正しく伝わるようになる。