### PR TITLE
fix: use Config aws profile/region in handle_list, handle_terminate, handle_status

### DIFF
--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -623,13 +623,17 @@ pub async fn handle_connect(
     Ok(())
 }
 
-pub async fn handle_list(_config: &Config) -> Result<()> {
+pub async fn handle_list(config: &Config) -> Result<()> {
     info!("Listing active sessions");
 
     println!("📋 Active Sessions:");
 
     // Create AWS manager to list sessions
-    let aws_manager = AwsManager::default().await?;
+    let aws_manager = AwsManager::new(
+        Some(config.aws.default_region.clone()),
+        config.aws.default_profile.clone(),
+    )
+    .await?;
 
     match aws_manager.list_active_sessions().await {
         Ok(sessions) => {
@@ -658,13 +662,17 @@ pub async fn handle_list(_config: &Config) -> Result<()> {
     Ok(())
 }
 
-pub async fn handle_terminate(session_id: String, _config: &Config) -> Result<()> {
+pub async fn handle_terminate(session_id: String, config: &Config) -> Result<()> {
     info!("Terminating session: {}", session_id);
 
     println!("🛑 Terminating session: {}", session_id);
 
     // Create AWS manager to terminate session
-    let aws_manager = AwsManager::default().await?;
+    let aws_manager = AwsManager::new(
+        Some(config.aws.default_region.clone()),
+        config.aws.default_profile.clone(),
+    )
+    .await?;
 
     match aws_manager.terminate_ssm_session(&session_id).await {
         Ok(_) => {
@@ -680,8 +688,12 @@ pub async fn handle_terminate(session_id: String, _config: &Config) -> Result<()
     Ok(())
 }
 
-pub async fn handle_status(session_id: Option<String>, _config: &Config) -> Result<()> {
-    let aws_manager = AwsManager::default().await?;
+pub async fn handle_status(session_id: Option<String>, config: &Config) -> Result<()> {
+    let aws_manager = AwsManager::new(
+        Some(config.aws.default_region.clone()),
+        config.aws.default_profile.clone(),
+    )
+    .await?;
 
     match session_id {
         Some(id) => {


### PR DESCRIPTION
## 概要

`handle_list` / `handle_terminate` / `handle_status` が `AwsManager::default()` で AWS クライアントを作成しており、`Config` の `aws.default_profile` / `aws.default_region` が無視されていたバグを修正。

Closes #101

## 変更内容

`src/commands/connect.rs` の3関数で:
- `_config` → `config` に変更（引数を実際に使用）
- `AwsManager::default().await?` → `AwsManager::new(Some(config.aws.default_region.clone()), config.aws.default_profile.clone()).await?` に置換

## 動作への影響

- `nimbus list` / `nimbus terminate` / `nimbus status` が設定ファイルの `aws.default_profile` / `aws.default_region` を正しく参照するようになる
- 複数 AWS アカウントを使うユーザーが意図しないアカウントのセッションを操作するリスクを解消