### PR TITLE
fix: add DiagnosticSettings validation to config.rs validate()

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -725,6 +725,35 @@ impl Config {
             );
         }
 
+        // Validate diagnostic configuration
+        if self.diagnostic.timeout_seconds == 0 {
+            anyhow::bail!("diagnostic.timeout_seconds must be greater than 0");
+        }
+
+        if self.diagnostic.port_scan_range == 0 {
+            anyhow::bail!("diagnostic.port_scan_range must be greater than 0");
+        }
+
+        if self.diagnostic.feedback_refresh_interval_ms == 0 {
+            anyhow::bail!("diagnostic.feedback_refresh_interval_ms must be greater than 0");
+        }
+
+        if self.diagnostic.feedback_refresh_interval_ms < 10 {
+            tracing::warn!(
+                "diagnostic.feedback_refresh_interval_ms is set to {}ms, which may cause high CPU usage",
+                self.diagnostic.feedback_refresh_interval_ms
+            );
+        }
+
+        let valid_report_formats = ["text", "json", "yaml"];
+        if !valid_report_formats.contains(&self.diagnostic.report_format.as_str()) {
+            anyhow::bail!(
+                "Invalid diagnostic.report_format '{}'. Must be one of: {}",
+                self.diagnostic.report_format,
+                valid_report_formats.join(", ")
+            );
+        }
+
         // Validate AWS configuration
         if self.aws.connection_timeout == 0 {
             anyhow::bail!("connection_timeout must be greater than 0");


### PR DESCRIPTION
## 概要

`config.rs` の `validate()` に `DiagnosticSettings` の検証を追加。

Closes #129

## 変更内容

AWS セクションの検証直前に以下の DiagnosticSettings 検証を追加:

- `timeout_seconds == 0` → bail（即タイムアウト防止）
- `port_scan_range == 0` → bail（代替ポート提案の機能不全防止）
- `feedback_refresh_interval_ms == 0` → bail（CPU 100% 使用防止）
- `feedback_refresh_interval_ms < 10` → warn（高 CPU 使用の警告）
- `report_format` が `text`/`json`/`yaml` 以外 → bail

## 動作への影響

- 既存のデフォルト設定値は全て検証を通過するため、既存ユーザーへの影響なし
- 無効な設定値を持つ TOML ファイルを使用した場合、起動時にエラーメッセージが表示される