### PR TITLE
docs: add SAFETY comments to unsafe blocks in reconnect.rs

### DIFF
--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -157,6 +157,9 @@ impl DefaultAutoReconnector {
             use winapi::um::processthreadsapi::{GetExitCodeProcess, OpenProcess};
             use winapi::um::winnt::PROCESS_QUERY_INFORMATION;
 
+            // SAFETY: `pid` is a valid process ID obtained from `child.id()`.
+            // `OpenProcess` returns null on failure (checked immediately after).
+            // `CloseHandle` is called on every path to prevent handle leaks.
             unsafe {
                 let handle = OpenProcess(PROCESS_QUERY_INFORMATION, 0, pid);
                 if handle.is_null() {
@@ -430,6 +433,9 @@ impl AutoReconnector for DefaultAutoReconnector {
                     use winapi::um::processthreadsapi::{OpenProcess, TerminateProcess};
                     use winapi::um::winnt::PROCESS_TERMINATE;
 
+                    // SAFETY: `pid` is a valid process ID obtained from `child.id()`.
+                    // `OpenProcess` returns null on failure (checked before use).
+                    // `CloseHandle` is called after `TerminateProcess` to prevent handle leaks.
                     unsafe {
                         let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
                         if !handle.is_null() {


### PR DESCRIPTION
## Summary
- `reconnect.rs` の Windows 実装にある `unsafe` ブロック2箇所に `// SAFETY:` コメントを追加
- `is_process_alive` (L160) と `attempt_reconnection` (L433) の安全性の根拠を明記

Closes #149

## Changes
- `OpenProcess` / `CloseHandle` / `TerminateProcess` / `GetExitCodeProcess` の各 FFI 呼び出しについて、pid の出所・null チェック・ハンドルリーク防止の根拠をコメント

## Impact
コメント追加のみ。動作への影響なし。