### PR TITLE
fix: correct `nimbus list-sessions` to `nimbus list` in help messages

### DIFF
--- a/src/user_messages.rs
+++ b/src/user_messages.rs
@@ -109,7 +109,7 @@ impl UserMessageSystem {
                     "新しいセッションを作成してください".to_string(),
                     "アクティブなセッションのリストを確認".to_string(),
                 ],
-                help_command: Some("nimbus list-sessions".to_string()),
+                help_command: Some("nimbus list".to_string()),
             },
             SessionError::CreationFailed { reason } => UserErrorMessage {
                 title: "セッションの作成に失敗しました".to_string(),
@@ -132,10 +132,10 @@ impl UserMessageSystem {
                 severity: "medium".to_string(),
                 solutions: vec![
                     "不要なセッションを終了してください".to_string(),
-                    "nimbus list-sessions で確認".to_string(),
+                    "nimbus list で確認".to_string(),
                     "nimbus terminate <session-id> で終了".to_string(),
                 ],
-                help_command: Some("nimbus list-sessions".to_string()),
+                help_command: Some("nimbus list".to_string()),
             },
             SessionError::ResourceLimitExceeded { resource, .. } => UserErrorMessage {
                 title: "リソース制限に達しました".to_string(),


### PR DESCRIPTION
## 概要

`user_messages.rs` のエラーメッセージが存在しないコマンド `nimbus list-sessions` を案内していた問題を修正。

Closes #142

## 変更内容

- `src/user_messages.rs` の3箇所で `"nimbus list-sessions"` → `"nimbus list"` に修正
  - L112: `SessionError::NotFound` の `help_command`
  - L135: `SessionError::LimitExceeded` の `solutions` テキスト
  - L138: `SessionError::LimitExceeded` の `help_command`

## 動作への影響

エラー発生時にユーザーへ案内されるコマンドが、実際に存在する `nimbus list` コマンドに修正される。